### PR TITLE
Fixed test_1_1_given_only_network_shape_redundancy

### DIFF
--- a/tests/test_indirect_analyses.py
+++ b/tests/test_indirect_analyses.py
@@ -9,7 +9,7 @@ from tests import test_data
 
 
 class TestIndirectAnalyses:
-    @pytest.mark.skip(reason="Work in progress.")
+    # @pytest.mark.skip(reason="Work in progress.")
     def test_1_1_given_only_network_shape_redundancy(self):
         """To test the graph and network creation from a shapefile. Also applies line segmentation for the network."""
         # 1. Given test data
@@ -21,8 +21,10 @@ class TestIndirectAnalyses:
         assert analysis_ini.is_file()
         # Purge output dirs.
         _output_graph_dir = _test_dir / "static" / "output_graph"
-        if _output_graph_dir.is_dir():
-            shutil.rmtree(_output_graph_dir)
+        if _output_graph_dir.is_dir():  # The output_graph directory should be empty, but should exist
+            files = _output_graph_dir.glob('*')
+            for f in files:
+                f.unlink()
         _output_files_dir = _test_dir / "output"
         if _output_files_dir.is_dir():
             shutil.rmtree(_output_files_dir)


### PR DESCRIPTION
Test test_1_1_given_only_network_shape_redundancy should run fine now, if you have a graph_output folder in /static