### PR TITLE
ci: Added extra jupyter notebook dependencies to binder environment.yml

### DIFF
--- a/examples/environment.yml
+++ b/examples/environment.yml
@@ -7,5 +7,8 @@ dependencies:
   - conda-forge::gdal=3.5.1
   - conda-forge::fiona
   - conda-forge::poetry=1.3.2
+  - conda-forge::folium
+  - conda-forge::matplotlib
+  - conda-forge::mapclassify
   - pip:
     - git+https://github.com/Deltares/ra2ce.git

--- a/poetry.lock
+++ b/poetry.lock
@@ -4589,4 +4589,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9, <3.11"
-content-hash = "4f4da2faabff7eedf8f601006d77e5ecb8e383cbb4aeff4116b79db30308e89a"
+content-hash = "f6498dc5d9fb6febb47f6df0e4a877372fb6bb5303a16338b71245090ddc4ee4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,12 @@ sphinx-design = "^0.4.1"
 ipykernel = "^6.25.1"
 pandoc = "^2.3"
 
+[tool.poetry.group.jupyter.dependencies]
+# These dependencies are required for binder (`examples\environment.yml`).
+folium = "^0.15.0"
+matplotlib = "^3.8.1"
+mapclassify = "^2.6.1"
+
 [tool.poetry.group.test.dependencies]
 pytest-cov = "^3.0.0"
 pytest = "^7.1.3"
@@ -81,9 +87,6 @@ teamcity-messages = "^1.32"
 testbook = "^0.4.2"
 pytest-xdist = "^3.3.1"
 pytest-profiling = "^1.7.0"
-folium = "^0.15.0"
-matplotlib = "^3.8.1"
-mapclassify = "^2.6.1"
 pytest-notebook = "^0.9.0"
 
 [tool.black]


### PR DESCRIPTION
In order to properly run all scripts, the binder environment requires some extra jupyter notebook dependencies.
What has been done:
- Separate such dependencie sin the `toml` for more visibility and maintainability.
- Added said dependencies to the `environment.yml` file in the examples directory, which is later used for binder.