### PR TITLE
ci: Updated workflow to use PAT secret and autocommit actiong

### DIFF
--- a/.github/workflows/normalize_code.yml
+++ b/.github/workflows/normalize_code.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check out
         uses: actions/checkout@v4
         with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
+          token: ${{ secrets.PAT }}
           fetch-depth: 0
 
       - name: Set up Python
@@ -52,13 +52,12 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Autoformat code if the check fails
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: |
           poetry run isort .
           poetry run black .
-          git config --global user.name '${{ github.actor }}'
-          git config --global user.email '${{ github.actor }}@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
-          git checkout $GITHUB_HEAD_REF
-          git commit -am "chore: autoformat isort & black" && git push --force || true
+  
+      - name: Push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with: 
+          commit_message: "chore: autoformat isort & black"
+          push_options: --force


### PR DESCRIPTION
## Issue addressed
The current pipeline for normalizing the code does not work due to the constrain of pushing to master via PR (and only admins can overrule this).

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [ ] I HAVE discussed my solution with (other) members of the RA2CE team.

## What has been done?
Created PAT of the admin (myself) and added it to the repo secrets.

### Checklist
- [x] Code is formatted using our custom `black` and `isort` definitions.
- [x] Tests are either added or updated.
- [x] Branch is up to date with `master`.
- [ ] Updated documentation if needed.

## Additional Notes (optional)
Ideally we use a PAT for the Deltares Service Account or a bot.
