### PR TITLE
Fix/468 set hazard field name to str

### DIFF
--- a/docs/network_module/network_module.rst
+++ b/docs/network_module/network_module.rst
@@ -187,6 +187,7 @@ Note: the origin-destination parameters are explained in the :ref:`analysis_modu
     [hazard]
     hazard_map = None                           # <name(s) of hazard maps in the static/hazard folder> / None
     hazard_id = None                            # <field name> / None
-    hazard_field_name = None                    # <field name(s)> / None
+    hazard_field_name = None                    # <field name> / None
     aggregate_wl = max                          # max / min / mean
     hazard_crs = None                           # EPSG code / projection that can be read by pyproj / None
+    overlay_segmented_graph = True              # True / False

--- a/examples/data/base_network/network.ini
+++ b/examples/data/base_network/network.ini
@@ -24,7 +24,7 @@ origin_out_fraction = 1                     # fraction of things/people going ou
 [hazard]
 hazard_map = None                           # <name(s) of hazard maps in the static/hazard folder> / None
 hazard_id = None                            # <field name> / None
-hazard_field_name = None                    # <field name(s)> / None
+hazard_field_name = None                    # <field name)> / None
 aggregate_wl = max                          # max / min / mean
 hazard_crs = None                           # EPSG code / projection that can be read by pyproj / None
 

--- a/examples/data/base_network_gpkg/network.ini
+++ b/examples/data/base_network_gpkg/network.ini
@@ -24,7 +24,7 @@ origin_out_fraction = None                     # fraction of things/people going
 [hazard]
 hazard_map = None                           # <name(s) of hazard maps in the static/hazard folder> / None
 hazard_id = None                            # <field name> / None
-hazard_field_name = None                    # <field name(s)> / None
+hazard_field_name = None                    # <field name> / None
 aggregate_wl = None                          # max / min / mean
 hazard_crs = None                           # EPSG code / projection that can be read by pyproj / None
 

--- a/examples/data/hazard_overlay/network.ini
+++ b/examples/data/hazard_overlay/network.ini
@@ -24,7 +24,7 @@ origin_out_fraction = 1                     # fraction of things/people going ou
 [hazard]
 hazard_map = max_flood_depth.tif                           # <name(s) of hazard maps in the static/hazard folder> / None
 hazard_id = None                            # <field name> / None
-hazard_field_name = None                    # <field name(s)> / None
+hazard_field_name = None                    # <field name> / None
 aggregate_wl = max                          # max / min / mean
 hazard_crs = EPSG:32736                           # EPSG code / projection that can be read by pyproj / None
 

--- a/examples/data/single_link_redun/network.ini
+++ b/examples/data/single_link_redun/network.ini
@@ -24,7 +24,7 @@ origin_out_fraction = 1                     # fraction of things/people going ou
 [hazard]
 hazard_map = None                           # <name(s) of hazard maps in the static/hazard folder> / None
 hazard_id = None                            # <field name> / None
-hazard_field_name = None                    # <field name(s)> / None
+hazard_field_name = None                    # <field name> / None
 aggregate_wl = max                          # max / min / mean
 hazard_crs = None                           # EPSG code / projection that can be read by pyproj / None
 

--- a/ra2ce/network/network_config_data/network_config_data.py
+++ b/ra2ce/network/network_config_data/network_config_data.py
@@ -78,7 +78,7 @@ class IsolationSection:
 class HazardSection:
     hazard_map: list[Path] = field(default_factory=list)
     hazard_id: str = ""
-    hazard_field_name: list[str] = field(default_factory=list)
+    hazard_field_name: str = ""
     aggregate_wl: AggregateWlEnum = field(default_factory=lambda: AggregateWlEnum.NONE)
     hazard_crs: str = ""
     scenario_cost: list[float] = field(default_factory=list)

--- a/ra2ce/network/network_config_data/network_config_data_reader.py
+++ b/ra2ce/network/network_config_data/network_config_data_reader.py
@@ -208,9 +208,6 @@ class NetworkConfigDataReader(ConfigDataReaderProtocol):
                 ),
             )
         )
-        _hazard_section.hazard_field_name = self._parser.getlist(
-            _section, "hazard_field_name", fallback=_hazard_section.hazard_field_name
-        )
         _hazard_section.aggregate_wl = AggregateWlEnum.get_enum(
             self._parser.get(_section, "aggregate_wl", fallback=None)
         )


### PR DESCRIPTION
## Issue addressed
Solves #468

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [x] I HAVE discussed my solution with (other) members of the RA2CE team.

## What has been done?
Adjust config and reading of `hazard_field_name` from `list[str]` to `str` as it is used everywhere in the code like that.

### Checklist
- [x] Code is formatted using our custom `black` and `isort` definitions.
- [x] Tests are either added or updated.
- [x] Branch is up to date with `master`.
- [x] Updated documentation if needed.

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
