### PR TITLE
Fix/433 avg speed 0

### DIFF
--- a/ra2ce/analysis/losses/losses.py
+++ b/ra2ce/analysis/losses/losses.py
@@ -169,13 +169,6 @@ class Losses(AnalysisLossesProtocol):
         {self.link_id} is passed for feature ids of the graph"""
             )
 
-    def _load_gdf(self, gdf_path: Path) -> gpd.GeoDataFrame:
-        """This method reads the dataframe created from a .csv"""
-        if gdf_path.exists():
-            return gpd.read_file(gdf_path, index_col=f"{self.link_id}")
-        logging.warning("No `gdf` file found at {}.".format(gdf_path))
-        return gpd.GeoDataFrame()
-
     def _get_vot_intensity_per_trip_purpose(self) -> dict[str, pd.DataFrame]:
         """
         Generates a dictionary with all available `vot_purpose` with their intensity as a `pd.DataFrame`.

--- a/ra2ce/analysis/losses/multi_link_redundancy.py
+++ b/ra2ce/analysis/losses/multi_link_redundancy.py
@@ -160,11 +160,9 @@ class MultiLinkRedundancy(AnalysisLossesProtocol):
                     )
                     alt_nodes = nx.dijkstra_path(_graph, u, v)
                     connected = 1
-                    alt_value = _weighing_analyser.calculate_alternative_distance(
-                        alt_dist
-                    )
+                    alt_value = _weighing_analyser.calculate_alternative_value(alt_dist)
                 else:
-                    alt_value = _weighing_analyser.calculate_distance()
+                    alt_value = _weighing_analyser.calculate_value()
                     alt_nodes, connected = np.NaN, 0
 
                 current_value = _weighing_analyser.weighing_data[

--- a/ra2ce/analysis/losses/multi_link_redundancy.py
+++ b/ra2ce/analysis/losses/multi_link_redundancy.py
@@ -148,7 +148,7 @@ class MultiLinkRedundancy(AnalysisLossesProtocol):
 
             df_calculated = pd.DataFrame(columns=columns)
             _weighing_analyser = WeighingAnalysisFactory.get_analysis(
-                self.analysis.weighing
+                self.analysis.weighing, gdf
             )
 
             for edges in edges_remove:
@@ -170,7 +170,7 @@ class MultiLinkRedundancy(AnalysisLossesProtocol):
                 ]
                 if not current_value:  # if None
                     current_value = np.nan
-                diff = round(alt_value - current_value, 3)
+                diff = round(alt_value - current_value, 7)
 
                 data = {
                     "u": [u],

--- a/ra2ce/analysis/losses/multi_link_redundancy.py
+++ b/ra2ce/analysis/losses/multi_link_redundancy.py
@@ -45,10 +45,7 @@ class MultiLinkRedundancy(AnalysisLossesProtocol):
         """
         updates the time column with the calculated dataframe and updates the rest of the gdf_graph if time is None.
         """
-        if (
-            WeighingEnum.TIME.config_value not in gdf_graph.columns
-            and WeighingEnum.TIME.config_value not in df_calculated.columns
-        ):
+        if WeighingEnum.TIME.config_value not in df_calculated.columns:
             return df_calculated, gdf_graph
 
         if (

--- a/ra2ce/analysis/losses/multi_link_redundancy.py
+++ b/ra2ce/analysis/losses/multi_link_redundancy.py
@@ -51,8 +51,13 @@ class MultiLinkRedundancy(AnalysisLossesProtocol):
         ):
             return df_calculated, gdf_graph
 
-        if WeighingEnum.TIME.config_value in df_calculated.columns:
-            df_calculated = df_calculated.drop(columns=[WeighingEnum.TIME.config_value])
+        if (
+            WeighingEnum.TIME.config_value in gdf_graph.columns
+            and WeighingEnum.TIME.config_value in df_calculated.columns
+        ):
+            df_calculated = df_calculated.drop(
+                columns=[WeighingEnum.TIME.config_value], errors="ignore"
+            )
             return df_calculated, gdf_graph
 
         gdf_graph[WeighingEnum.TIME.config_value] = df_calculated[

--- a/ra2ce/analysis/losses/multi_link_redundancy.py
+++ b/ra2ce/analysis/losses/multi_link_redundancy.py
@@ -55,9 +55,7 @@ class MultiLinkRedundancy(AnalysisLossesProtocol):
             WeighingEnum.TIME.config_value in gdf_graph.columns
             and WeighingEnum.TIME.config_value in df_calculated.columns
         ):
-            df_calculated = df_calculated.drop(
-                columns=[WeighingEnum.TIME.config_value], errors="ignore"
-            )
+            df_calculated = df_calculated.drop(columns=[WeighingEnum.TIME.config_value])
             return df_calculated, gdf_graph
 
         gdf_graph[WeighingEnum.TIME.config_value] = df_calculated[

--- a/ra2ce/analysis/losses/multi_link_redundancy.py
+++ b/ra2ce/analysis/losses/multi_link_redundancy.py
@@ -45,15 +45,6 @@ class MultiLinkRedundancy(AnalysisLossesProtocol):
         """
         updates the time column with the calculated dataframe and updates the rest of the gdf_graph if time is None.
         """
-        # TODO: can this first branch be deleted since it is done (better) in the 3rd branch?
-        # In that case a drop of the time column should be done in the 3rd branch.
-        if (
-            WeighingEnum.TIME.config_value in gdf_graph.columns
-            and WeighingEnum.TIME.config_value in df_calculated.columns
-        ):
-            df_calculated = df_calculated.drop(columns=[WeighingEnum.TIME.config_value])
-            return df_calculated, gdf_graph
-
         if (
             WeighingEnum.TIME.config_value not in gdf_graph.columns
             and WeighingEnum.TIME.config_value not in df_calculated.columns
@@ -61,25 +52,27 @@ class MultiLinkRedundancy(AnalysisLossesProtocol):
             return df_calculated, gdf_graph
 
         if WeighingEnum.TIME.config_value in df_calculated.columns:
-            gdf_graph[WeighingEnum.TIME.config_value] = df_calculated[
-                WeighingEnum.TIME.config_value
-            ]
-            for i, row in gdf_graph.iterrows():
-                row_avgspeed = row.get("avgspeed", None)
-                row_length = row.get("length", None)
-                if (
-                    pd.isna(row[WeighingEnum.TIME.config_value])
-                    and row_avgspeed
-                    and row_length
-                ):
-                    gdf_graph.at[i, WeighingEnum.TIME.config_value] = (
-                        row_length * 1e-3 / row_avgspeed
-                    )
-                else:
-                    gdf_graph.at[i, WeighingEnum.TIME.config_value] = row.get(
-                        WeighingEnum.TIME.config_value, None
-                    )
+            df_calculated = df_calculated.drop(columns=[WeighingEnum.TIME.config_value])
+            return df_calculated, gdf_graph
 
+        gdf_graph[WeighingEnum.TIME.config_value] = df_calculated[
+            WeighingEnum.TIME.config_value
+        ]
+        for i, row in gdf_graph.iterrows():
+            row_avgspeed = row.get("avgspeed", None)
+            row_length = row.get("length", None)
+            if (
+                pd.isna(row[WeighingEnum.TIME.config_value])
+                and row_avgspeed
+                and row_length
+            ):
+                gdf_graph.at[i, WeighingEnum.TIME.config_value] = (
+                    row_length * 1e-3 / row_avgspeed
+                )
+            else:
+                gdf_graph.at[i, WeighingEnum.TIME.config_value] = row.get(
+                    WeighingEnum.TIME.config_value, None
+                )
         return df_calculated, gdf_graph
 
     def execute(self) -> gpd.GeoDataFrame:
@@ -157,11 +150,11 @@ class MultiLinkRedundancy(AnalysisLossesProtocol):
             # Ensure each edge has a valid weighing attribute
             _current_value_list = []
             for edge in list(edges_remove):
-                u, v, k, _weighing_analyser.edge_data = edge
+                _weighing_analyser.edge_data = edge[3]
                 _current_value_list.append(_weighing_analyser.get_current_value())
 
             for e, edges in enumerate(edges_remove):
-                u, v, k, _weighing_analyser.edge_data = edges
+                u, v, _, _weighing_analyser.edge_data = edges
 
                 if nx.has_path(_graph, u, v):
                     alt_dist = nx.dijkstra_path_length(

--- a/ra2ce/analysis/losses/multi_link_redundancy.py
+++ b/ra2ce/analysis/losses/multi_link_redundancy.py
@@ -158,7 +158,7 @@ class MultiLinkRedundancy(AnalysisLossesProtocol):
                 u, v, k, _weighing_analyser.edge_data = edges
 
                 if nx.has_path(_graph, u, v):
-                    current_value = _weighing_analyser.calculate_current_value()
+                    current_value = _weighing_analyser.get_current_value()
 
                     alt_dist = nx.dijkstra_path_length(
                         _graph, u, v, weight=WeighingEnum.LENGTH.config_value
@@ -169,7 +169,7 @@ class MultiLinkRedundancy(AnalysisLossesProtocol):
 
                     diff = round(alt_value - current_value, 7)
                 else:
-                    alt_value = _weighing_analyser.calculate_current_value()
+                    alt_value = _weighing_analyser.get_current_value()
                     alt_nodes, connected = np.NaN, 0
                     diff = np.NaN
 

--- a/ra2ce/analysis/losses/single_link_redundancy.py
+++ b/ra2ce/analysis/losses/single_link_redundancy.py
@@ -62,7 +62,7 @@ class SingleLinkRedundancy(AnalysisLossesProtocol):
 
         # Ensure each edge has a valid weighing attribute
         for edge in list(self.graph_file.graph.edges.data(keys=True)):
-            u, v, k, _weighing_analyser.edge_data = edge
+            _weighing_analyser.edge_data = edge[3]
             _current_value_list.append(_weighing_analyser.get_current_value())
 
         # Loop over all edges to temporarily remove them and calculate the alternative route

--- a/ra2ce/analysis/losses/single_link_redundancy.py
+++ b/ra2ce/analysis/losses/single_link_redundancy.py
@@ -50,6 +50,7 @@ class SingleLinkRedundancy(AnalysisLossesProtocol):
         _gdf_graph = osmnx.graph_to_gdfs(self.graph_file.get_graph(), nodes=False)
 
         # list for the length of the alternative routes
+        _current_value_list = []
         _alt_value_list = []
         _alt_nodes_list = []
         _diff_value_list = []
@@ -58,19 +59,27 @@ class SingleLinkRedundancy(AnalysisLossesProtocol):
         _weighing_analyser = WeighingAnalysisFactory.get_analysis(
             self.analysis.weighing, _gdf_graph
         )
-        for e_remove in list(self.graph_file.graph.edges.data(keys=True)):
+
+        # Ensure each edge has a valid weighing attribute
+        for edge in list(self.graph_file.graph.edges.data(keys=True)):
+            u, v, k, _weighing_analyser.edge_data = edge
+            _current_value_list.append(_weighing_analyser.get_current_value())
+
+        # Loop over all edges to temporarily remove them and calculate the alternative route
+        for e, e_remove in enumerate(list(self.graph_file.graph.edges.data(keys=True))):
             u, v, k, _weighing_analyser.edge_data = e_remove
 
-            # if data['highway'] in attr_list:
             # remove the edge
             self.graph_file.graph.remove_edge(u, v, k)
 
             if nx.has_path(self.graph_file.graph, u, v):
-                _current_value = _weighing_analyser.calculate_current_value()
 
                 # calculate the alternative distance if that edge is unavailable
                 _alt_dist = nx.dijkstra_path_length(
-                    self.graph_file.graph, u, v, weight=WeighingEnum.LENGTH.config_value
+                    self.graph_file.graph,
+                    u,
+                    v,
+                    weight=self.analysis.weighing.config_value,
                 )
                 _alt_nodes = nx.dijkstra_path(self.graph_file.graph, u, v)
                 _alt_value = _weighing_analyser.calculate_alternative_value(_alt_dist)
@@ -80,11 +89,11 @@ class SingleLinkRedundancy(AnalysisLossesProtocol):
                 _alt_nodes_list.append(_alt_nodes)
 
                 # calculate the difference in distance
-                _diff_value_list.append(round(_alt_value - _current_value, 7))
+                _diff_value_list.append(round(_alt_value - _current_value_list[e], 7))
 
                 _detour_exist_list.append(1)
             else:
-                _alt_value_list.append(_weighing_analyser.calculate_current_value())
+                _alt_value_list.append(_current_value_list[e])
                 _alt_nodes_list.append(math.nan)
                 _diff_value_list.append(math.nan)
                 _detour_exist_list.append(0)
@@ -93,6 +102,7 @@ class SingleLinkRedundancy(AnalysisLossesProtocol):
             self.graph_file.graph.add_edge(u, v, k, **_weighing_analyser.edge_data)
 
         # Add the new columns to the geodataframe
+        _gdf_graph[self.analysis.weighing.config_value] = _current_value_list
         _gdf_graph[f"alt_{self.analysis.weighing.config_value}"] = _alt_value_list
         _gdf_graph["alt_nodes"] = _alt_nodes_list
         _gdf_graph[f"diff_{self.analysis.weighing.config_value}"] = _diff_value_list

--- a/ra2ce/analysis/losses/single_link_redundancy.py
+++ b/ra2ce/analysis/losses/single_link_redundancy.py
@@ -89,7 +89,7 @@ class SingleLinkRedundancy(AnalysisLossesProtocol):
                 _alt_nodes_list.append(_alt_nodes)
 
                 # calculate the difference in distance
-                _diff_value_list.append(round(_alt_value - _current_value_list[e], 7))
+                _diff_value_list.append(round(_alt_value - _current_value_list[e], 3))
 
                 _detour_exist_list.append(1)
             else:

--- a/ra2ce/analysis/losses/single_link_redundancy.py
+++ b/ra2ce/analysis/losses/single_link_redundancy.py
@@ -1,7 +1,7 @@
+import math
 from pathlib import Path
 
 import networkx as nx
-import numpy as np
 import osmnx
 from geopandas import GeoDataFrame
 
@@ -67,20 +67,20 @@ class SingleLinkRedundancy(AnalysisLossesProtocol):
 
             if nx.has_path(self.graph_file.graph, u, v):
                 # calculate the alternative distance if that edge is unavailable
-                alt_dist = nx.dijkstra_path_length(
+                _alt_dist = nx.dijkstra_path_length(
                     self.graph_file.graph, u, v, weight=WeighingEnum.LENGTH.config_value
                 )
-                alt_nodes = nx.dijkstra_path(self.graph_file.graph, u, v)
-                alt_value = _weighing_analyser.calculate_alternative_distance(alt_dist)
+                _alt_nodes = nx.dijkstra_path(self.graph_file.graph, u, v)
+                _alt_value = _weighing_analyser.calculate_alternative_value(_alt_dist)
 
                 # append alternative route nodes
-                _alt_value_list.append(alt_value)
-                _alt_nodes_list.append(alt_nodes)
+                _alt_value_list.append(_alt_value)
+                _alt_nodes_list.append(_alt_nodes)
 
                 # calculate the difference in distance
                 _diff_value_list.append(
                     round(
-                        alt_value
+                        _alt_value
                         - _weighing_analyser.weighing_data[
                             self.analysis.weighing.config_value
                         ],
@@ -90,9 +90,9 @@ class SingleLinkRedundancy(AnalysisLossesProtocol):
 
                 _detour_exist_list.append(1)
             else:
-                _alt_value_list.append(_weighing_analyser.calculate_distance())
-                _alt_nodes_list.append(np.NaN)
-                _diff_value_list.append(np.NaN)
+                _alt_value_list.append(_weighing_analyser.calculate_value())
+                _alt_nodes_list.append(math.nan)
+                _diff_value_list.append(math.nan)
                 _detour_exist_list.append(0)
 
             # add edge again to the graph

--- a/ra2ce/analysis/losses/single_link_redundancy.py
+++ b/ra2ce/analysis/losses/single_link_redundancy.py
@@ -8,7 +8,6 @@ from geopandas import GeoDataFrame
 from ra2ce.analysis.analysis_config_data.analysis_config_data import (
     AnalysisSectionLosses,
 )
-from ra2ce.analysis.analysis_config_data.enums.weighing_enum import WeighingEnum
 from ra2ce.analysis.analysis_input_wrapper import AnalysisInputWrapper
 from ra2ce.analysis.losses.analysis_losses_protocol import AnalysisLossesProtocol
 from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_factory import (

--- a/ra2ce/analysis/losses/single_link_redundancy.py
+++ b/ra2ce/analysis/losses/single_link_redundancy.py
@@ -56,7 +56,7 @@ class SingleLinkRedundancy(AnalysisLossesProtocol):
         _detour_exist_list = []
 
         _weighing_analyser = WeighingAnalysisFactory.get_analysis(
-            self.analysis.weighing
+            self.analysis.weighing, _gdf_graph
         )
         for e_remove in list(self.graph_file.graph.edges.data(keys=True)):
             u, v, k, _weighing_analyser.weighing_data = e_remove
@@ -78,15 +78,8 @@ class SingleLinkRedundancy(AnalysisLossesProtocol):
                 _alt_nodes_list.append(_alt_nodes)
 
                 # calculate the difference in distance
-                _diff_value_list.append(
-                    round(
-                        _alt_value
-                        - _weighing_analyser.weighing_data[
-                            self.analysis.weighing.config_value
-                        ],
-                        7,
-                    )
-                )
+                _orig_value = _weighing_analyser.calculate_value()
+                _diff_value_list.append(round(_alt_value - _orig_value, 7))
 
                 _detour_exist_list.append(1)
             else:

--- a/ra2ce/analysis/losses/weighing_analysis/length_weighing_analysis.py
+++ b/ra2ce/analysis/losses/weighing_analysis/length_weighing_analysis.py
@@ -1,5 +1,6 @@
+import math
+
 import geopandas as gpd
-import numpy as np
 
 from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
     WeighingAnalysisProtocol,
@@ -9,10 +10,10 @@ from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
 class LengthWeighingAnalysis(WeighingAnalysisProtocol):
     weighing_data: dict
 
-    def calculate_distance(self) -> float:
-        return np.nan
+    def calculate_value(self) -> float:
+        return math.nan
 
-    def calculate_alternative_distance(self, alt_dist: float) -> float:
+    def calculate_alternative_value(self, alt_dist: float) -> float:
         return alt_dist
 
     def extend_graph(self, gdf_graph: gpd.GeoDataFrame | dict) -> None:

--- a/ra2ce/analysis/losses/weighing_analysis/length_weighing_analysis.py
+++ b/ra2ce/analysis/losses/weighing_analysis/length_weighing_analysis.py
@@ -1,4 +1,5 @@
 import math
+from typing import Any
 
 import geopandas as gpd
 
@@ -8,7 +9,11 @@ from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
 
 
 class LengthWeighingAnalysis(WeighingAnalysisProtocol):
-    weighing_data: dict
+    weighing_data: dict[str, Any]
+    avgspeed_dict: dict[str, float]
+
+    def __init__(self) -> None:
+        pass
 
     def calculate_value(self) -> float:
         return math.nan

--- a/ra2ce/analysis/losses/weighing_analysis/length_weighing_analysis.py
+++ b/ra2ce/analysis/losses/weighing_analysis/length_weighing_analysis.py
@@ -14,7 +14,7 @@ class LengthWeighingAnalysis(WeighingAnalysisProtocol):
     edge_data: dict[str, Any]
     avgspeed_dict: dict[str, float]
 
-    def __init__(self, gdf_graph: gpd.GeoDataFrame) -> None:
+    def __init__(self, gdf_graph: gpd.GeoDataFrame | None) -> None:
         self.avgspeed_dict = {
             _road_type.config_value: get_avgspeed_per_road_type(gdf_graph, _road_type)
             for _road_type in RoadTypeEnum
@@ -24,7 +24,7 @@ class LengthWeighingAnalysis(WeighingAnalysisProtocol):
         _avgspeed = self.edge_data.get("avgspeed", None)  # km/h
         if not _avgspeed:
             _avgspeed = self.avgspeed_dict[self.edge_data["highway"]]
-        return round(time * 3600 * _avgspeed, 1)  # m
+        return round(time * _avgspeed * 1e3, 1)  # m
 
     def get_current_value(self) -> float:
         _dist = self.edge_data.get(WeighingEnum.LENGTH.config_value, None)  # h

--- a/ra2ce/analysis/losses/weighing_analysis/length_weighing_analysis.py
+++ b/ra2ce/analysis/losses/weighing_analysis/length_weighing_analysis.py
@@ -1,8 +1,6 @@
 import math
 from typing import Any
 
-import geopandas as gpd
-
 from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
     WeighingAnalysisProtocol,
 )
@@ -10,16 +8,12 @@ from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
 
 class LengthWeighingAnalysis(WeighingAnalysisProtocol):
     weighing_data: dict[str, Any]
-    avgspeed_dict: dict[str, float]
 
     def __init__(self) -> None:
         pass
 
-    def calculate_value(self) -> float:
+    def calculate_current_value(self) -> float:
         return math.nan
 
     def calculate_alternative_value(self, alt_dist: float) -> float:
         return alt_dist
-
-    def extend_graph(self, gdf_graph: gpd.GeoDataFrame | dict) -> None:
-        return

--- a/ra2ce/analysis/losses/weighing_analysis/length_weighing_analysis.py
+++ b/ra2ce/analysis/losses/weighing_analysis/length_weighing_analysis.py
@@ -1,19 +1,39 @@
-import math
 from typing import Any
 
+import geopandas as gpd
+
+from ra2ce.analysis.analysis_config_data.enums.weighing_enum import WeighingEnum
 from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
     WeighingAnalysisProtocol,
 )
+from ra2ce.network.network_config_data.enums.road_type_enum import RoadTypeEnum
+from ra2ce.network.networks_utils import get_avgspeed_per_road_type
 
 
 class LengthWeighingAnalysis(WeighingAnalysisProtocol):
-    weighing_data: dict[str, Any]
+    edge_data: dict[str, Any]
+    avgspeed_dict: dict[str, float]
 
-    def __init__(self) -> None:
-        pass
+    def __init__(self, gdf_graph: gpd.GeoDataFrame) -> None:
+        self.avgspeed_dict = {
+            _road_type.config_value: get_avgspeed_per_road_type(gdf_graph, _road_type)
+            for _road_type in RoadTypeEnum
+        }
 
-    def calculate_current_value(self) -> float:
-        return math.nan
+    def _calculate_distance(self, time: float) -> float:
+        _avgspeed = self.edge_data.get("avgspeed", None)  # km/h
+        if not _avgspeed:
+            _avgspeed = self.avgspeed_dict[self.edge_data["highway"]]
+        return round(time * 3600 * _avgspeed, 1)  # m
+
+    def get_current_value(self) -> float:
+        _dist = self.edge_data.get(WeighingEnum.LENGTH.config_value, None)  # h
+        if _dist:
+            return round(_dist, 1)
+        _time = self.edge_data.get(WeighingEnum.TIME.config_value, 0)  # m
+        _dist = self._calculate_distance(_time)
+        self.edge_data[WeighingEnum.LENGTH.config_value] = _dist
+        return _dist
 
     def calculate_alternative_value(self, alt_dist: float) -> float:
         return alt_dist

--- a/ra2ce/analysis/losses/weighing_analysis/time_weighing_analysis.py
+++ b/ra2ce/analysis/losses/weighing_analysis/time_weighing_analysis.py
@@ -6,15 +6,19 @@ from ra2ce.analysis.analysis_config_data.enums.weighing_enum import WeighingEnum
 from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
     WeighingAnalysisProtocol,
 )
+from ra2ce.network.network_config_data.enums.road_type_enum import RoadTypeEnum
+from ra2ce.network.networks_utils import get_avgspeed_per_road_type
 
 
 class TimeWeighingAnalysis(WeighingAnalysisProtocol):
-    time_list: list[float]
     weighing_data: dict[str, Any]
     avgspeed_dict: dict[str, float]
 
-    def __init__(self) -> None:
-        self.time_list = []
+    def __init__(self, gdf_graph: gpd.GeoDataFrame) -> None:
+        self.avgspeed_dict = {
+            _road_type.config_value: get_avgspeed_per_road_type(gdf_graph, _road_type)
+            for _road_type in RoadTypeEnum
+        }
 
     def _calculate_time(self, dist: float) -> float:
         _avgspeed = self.weighing_data.get("avgspeed", None)  # km/h
@@ -25,18 +29,11 @@ class TimeWeighingAnalysis(WeighingAnalysisProtocol):
             7,
         )  # h
 
-    def calculate_value(self) -> float:
+    def calculate_current_value(self) -> float:
         _dist = self.weighing_data.get("length", 0)  # m
         _time = self._calculate_time(_dist)
         self.weighing_data[WeighingEnum.TIME.config_value] = _time
-        self.time_list.append(_time)
         return _time
 
     def calculate_alternative_value(self, alt_dist: float) -> float:
         return self._calculate_time(alt_dist)
-
-    def extend_graph(self, gdf_graph: gpd.GeoDataFrame | dict) -> None:
-        if isinstance(gdf_graph, gpd.GeoDataFrame):
-            gdf_graph[WeighingEnum.TIME.config_value] = self.time_list
-        elif isinstance(gdf_graph, dict):
-            gdf_graph[WeighingEnum.TIME.config_value] = [self.time_list[-1]]

--- a/ra2ce/analysis/losses/weighing_analysis/time_weighing_analysis.py
+++ b/ra2ce/analysis/losses/weighing_analysis/time_weighing_analysis.py
@@ -1,4 +1,4 @@
-import math
+from typing import Any
 
 import geopandas as gpd
 
@@ -9,36 +9,31 @@ from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
 
 
 class TimeWeighingAnalysis(WeighingAnalysisProtocol):
-    time_list: list
-    weighing_data: dict
-    default_avgspeed: float = math.inf
+    time_list: list[float]
+    weighing_data: dict[str, Any]
+    avgspeed_dict: dict[str, float]
 
     def __init__(self) -> None:
         self.time_list = []
 
-    def _calculate_time(self) -> float:
-        length = self.weighing_data.get("length", 0)
-        avgspeed = self.weighing_data.get("avgspeed", None)
-        if not avgspeed:
-            avgspeed = self.default_avgspeed
-        _calculated_time = round(
-            (length * 1e-3) / avgspeed,
-            3,
-        )  # in hours and avg speed in km/h
-        self.weighing_data[WeighingEnum.TIME.config_value] = _calculated_time
-        return round(_calculated_time, 3)
+    def _calculate_time(self, dist: float) -> float:
+        _avgspeed = self.weighing_data.get("avgspeed", None)  # km/h
+        if not _avgspeed:
+            _avgspeed = self.avgspeed_dict[self.weighing_data["highway"]]
+        return round(
+            (dist * 1e-3) / _avgspeed,
+            7,
+        )  # h
 
     def calculate_value(self) -> float:
-        self.time_list.append(self._calculate_time())
-        return self.time_list[-1]
+        _dist = self.weighing_data.get("length", 0)  # m
+        _time = self._calculate_time(_dist)
+        self.weighing_data[WeighingEnum.TIME.config_value] = _time
+        self.time_list.append(_time)
+        return _time
 
     def calculate_alternative_value(self, alt_dist: float) -> float:
-        avgspeed = self.weighing_data.get("avgspeed", None)
-        if not avgspeed:
-            avgspeed = self.default_avgspeed
-        alt_time = (alt_dist * 1e-3) / avgspeed  # in hours
-        self.time_list.append(self._calculate_time())
-        return alt_time
+        return self._calculate_time(alt_dist)
 
     def extend_graph(self, gdf_graph: gpd.GeoDataFrame | dict) -> None:
         if isinstance(gdf_graph, gpd.GeoDataFrame):

--- a/ra2ce/analysis/losses/weighing_analysis/time_weighing_analysis.py
+++ b/ra2ce/analysis/losses/weighing_analysis/time_weighing_analysis.py
@@ -14,7 +14,7 @@ class TimeWeighingAnalysis(WeighingAnalysisProtocol):
     edge_data: dict[str, Any]
     avgspeed_dict: dict[str, float]
 
-    def __init__(self, gdf_graph: gpd.GeoDataFrame) -> None:
+    def __init__(self, gdf_graph: gpd.GeoDataFrame | None) -> None:
         self.avgspeed_dict = {
             _road_type.config_value: get_avgspeed_per_road_type(gdf_graph, _road_type)
             for _road_type in RoadTypeEnum

--- a/ra2ce/analysis/losses/weighing_analysis/time_weighing_analysis.py
+++ b/ra2ce/analysis/losses/weighing_analysis/time_weighing_analysis.py
@@ -11,7 +11,7 @@ from ra2ce.network.networks_utils import get_avgspeed_per_road_type
 
 
 class TimeWeighingAnalysis(WeighingAnalysisProtocol):
-    weighing_data: dict[str, Any]
+    edge_data: dict[str, Any]
     avgspeed_dict: dict[str, float]
 
     def __init__(self, gdf_graph: gpd.GeoDataFrame) -> None:
@@ -21,18 +21,18 @@ class TimeWeighingAnalysis(WeighingAnalysisProtocol):
         }
 
     def _calculate_time(self, dist: float) -> float:
-        _avgspeed = self.weighing_data.get("avgspeed", None)  # km/h
+        _avgspeed = self.edge_data.get("avgspeed", None)  # km/h
         if not _avgspeed:
-            _avgspeed = self.avgspeed_dict[self.weighing_data["highway"]]
-        return round(
-            (dist * 1e-3) / _avgspeed,
-            7,
-        )  # h
+            _avgspeed = self.avgspeed_dict[self.edge_data["highway"]]
+        return round(dist * 1e-3 / _avgspeed, 3)  # h
 
-    def calculate_current_value(self) -> float:
-        _dist = self.weighing_data.get("length", 0)  # m
+    def get_current_value(self) -> float:
+        _time = self.edge_data.get(WeighingEnum.TIME.config_value, None)  # h
+        if _time:
+            return round(_time, 3)
+        _dist = self.edge_data.get(WeighingEnum.LENGTH.config_value, 0)  # m
         _time = self._calculate_time(_dist)
-        self.weighing_data[WeighingEnum.TIME.config_value] = _time
+        self.edge_data[WeighingEnum.TIME.config_value] = _time
         return _time
 
     def calculate_alternative_value(self, alt_dist: float) -> float:

--- a/ra2ce/analysis/losses/weighing_analysis/time_weighing_analysis.py
+++ b/ra2ce/analysis/losses/weighing_analysis/time_weighing_analysis.py
@@ -11,22 +11,22 @@ from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
 class TimeWeighingAnalysis(WeighingAnalysisProtocol):
     time_list: list
     weighing_data: dict
+    default_avgspeed: float = math.inf
 
     def __init__(self) -> None:
         self.time_list = []
 
     def _calculate_time(self) -> float:
-        length = self.weighing_data.get("length", None)
+        length = self.weighing_data.get("length", 0)
         avgspeed = self.weighing_data.get("avgspeed", None)
-        if length and avgspeed:
-            _calculated_time = round(
-                (length * 1e-3) / avgspeed,
-                3,
-            )  # in hours and avg speed in km/h
-            self.weighing_data[WeighingEnum.TIME.config_value] = _calculated_time
-            return round(_calculated_time, 3)
-        else:
-            return math.nan
+        if not avgspeed:
+            avgspeed = self.default_avgspeed
+        _calculated_time = round(
+            (length * 1e-3) / avgspeed,
+            3,
+        )  # in hours and avg speed in km/h
+        self.weighing_data[WeighingEnum.TIME.config_value] = _calculated_time
+        return round(_calculated_time, 3)
 
     def calculate_value(self) -> float:
         self.time_list.append(self._calculate_time())
@@ -34,12 +34,11 @@ class TimeWeighingAnalysis(WeighingAnalysisProtocol):
 
     def calculate_alternative_value(self, alt_dist: float) -> float:
         avgspeed = self.weighing_data.get("avgspeed", None)
-        if avgspeed:
-            alt_time = (alt_dist * 1e-3) / avgspeed  # in hours
-            self.time_list.append(self._calculate_time())
-            return alt_time
-        else:
-            return math.nan
+        if not avgspeed:
+            avgspeed = self.default_avgspeed
+        alt_time = (alt_dist * 1e-3) / avgspeed  # in hours
+        self.time_list.append(self._calculate_time())
+        return alt_time
 
     def extend_graph(self, gdf_graph: gpd.GeoDataFrame | dict) -> None:
         if isinstance(gdf_graph, gpd.GeoDataFrame):

--- a/ra2ce/analysis/losses/weighing_analysis/time_weighing_analysis.py
+++ b/ra2ce/analysis/losses/weighing_analysis/time_weighing_analysis.py
@@ -1,5 +1,6 @@
+import math
+
 import geopandas as gpd
-import numpy as np
 
 from ra2ce.analysis.analysis_config_data.enums.weighing_enum import WeighingEnum
 from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
@@ -25,20 +26,20 @@ class TimeWeighingAnalysis(WeighingAnalysisProtocol):
             self.weighing_data[WeighingEnum.TIME.config_value] = _calculated_time
             return round(_calculated_time, 3)
         else:
-            return np.nan
+            return math.nan
 
-    def calculate_distance(self) -> float:
+    def calculate_value(self) -> float:
         self.time_list.append(self._calculate_time())
         return self.time_list[-1]
 
-    def calculate_alternative_distance(self, alt_dist: float) -> float:
+    def calculate_alternative_value(self, alt_dist: float) -> float:
         avgspeed = self.weighing_data.get("avgspeed", None)
         if avgspeed:
             alt_time = (alt_dist * 1e-3) / avgspeed  # in hours
             self.time_list.append(self._calculate_time())
             return alt_time
         else:
-            return np.nan
+            return math.nan
 
     def extend_graph(self, gdf_graph: gpd.GeoDataFrame | dict) -> None:
         if isinstance(gdf_graph, gpd.GeoDataFrame):

--- a/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_factory.py
+++ b/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_factory.py
@@ -15,7 +15,7 @@ from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
 class WeighingAnalysisFactory:
     @staticmethod
     def get_analysis(
-        weighing_type: WeighingEnum, gdf_graph: gpd.GeoDataFrame
+        weighing_type: WeighingEnum, gdf_graph: gpd.GeoDataFrame | None
     ) -> WeighingAnalysisProtocol:
         if weighing_type == WeighingEnum.TIME:
             _analysis = TimeWeighingAnalysis(gdf_graph)

--- a/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_factory.py
+++ b/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_factory.py
@@ -1,5 +1,3 @@
-import math
-
 import geopandas as gpd
 
 from ra2ce.analysis.analysis_config_data.enums.weighing_enum import WeighingEnum
@@ -12,7 +10,6 @@ from ra2ce.analysis.losses.weighing_analysis.time_weighing_analysis import (
 from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
     WeighingAnalysisProtocol,
 )
-from ra2ce.network.network_config_data.enums.road_type_enum import RoadTypeEnum
 
 
 class WeighingAnalysisFactory:
@@ -20,33 +17,12 @@ class WeighingAnalysisFactory:
     def get_analysis(
         weighing_type: WeighingEnum, gdf_graph: gpd.GeoDataFrame
     ) -> WeighingAnalysisProtocol:
-        def _get_avgspeed_for_roadtype(
-            gdf_graph: gpd.GeoDataFrame, road_type: RoadTypeEnum
-        ) -> float:
-            # get the average speed for the road type
-            _avgspeed = gdf_graph[gdf_graph["highway"] == road_type.config_value][
-                "avgspeed"
-            ]
-            _avg = _avgspeed[_avgspeed > 0].mean()
-            if not _avg or math.isnan(_avg):
-                # if the average speed is not available,
-                # get the average speed of the whole graph
-                _avgspeed = gdf_graph["avgspeed"]
-                return _avgspeed[_avgspeed > 0].mean()
-            return _avg
-
         if weighing_type == WeighingEnum.TIME:
-            _analysis = TimeWeighingAnalysis()
+            _analysis = TimeWeighingAnalysis(gdf_graph)
         elif weighing_type == WeighingEnum.LENGTH:
             _analysis = LengthWeighingAnalysis()
         else:
             raise NotImplementedError(
                 "Weighing type {} not yet supported.".format(weighing_type)
             )
-
-        _analysis.avgspeed_dict = {
-            _road_type.config_value: _get_avgspeed_for_roadtype(gdf_graph, _road_type)
-            for _road_type in RoadTypeEnum
-        }
-
         return _analysis

--- a/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_factory.py
+++ b/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_factory.py
@@ -1,3 +1,7 @@
+import math
+
+import geopandas as gpd
+
 from ra2ce.analysis.analysis_config_data.enums.weighing_enum import WeighingEnum
 from ra2ce.analysis.losses.weighing_analysis.length_weighing_analysis import (
     LengthWeighingAnalysis,
@@ -8,16 +12,41 @@ from ra2ce.analysis.losses.weighing_analysis.time_weighing_analysis import (
 from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
     WeighingAnalysisProtocol,
 )
+from ra2ce.network.network_config_data.enums.road_type_enum import RoadTypeEnum
 
 
 class WeighingAnalysisFactory:
     @staticmethod
-    def get_analysis(weighing_type: WeighingEnum) -> WeighingAnalysisProtocol:
-        if weighing_type == WeighingEnum.TIME:
-            return TimeWeighingAnalysis()
-        if weighing_type == WeighingEnum.LENGTH:
-            return LengthWeighingAnalysis()
+    def get_analysis(
+        weighing_type: WeighingEnum, gdf_graph: gpd.GeoDataFrame
+    ) -> WeighingAnalysisProtocol:
+        def _get_avgspeed_for_roadtype(
+            gdf_graph: gpd.GeoDataFrame, road_type: RoadTypeEnum
+        ) -> float:
+            # get the average speed for the road type
+            _avgspeed = gdf_graph[gdf_graph["highway"] == road_type.config_value][
+                "avgspeed"
+            ]
+            _avg = _avgspeed[_avgspeed > 0].mean()
+            if not _avg or math.isnan(_avg):
+                # if the average speed is not available,
+                # get the average speed of the whole graph
+                _avgspeed = gdf_graph["avgspeed"]
+                return _avgspeed[_avgspeed > 0].mean()
+            return _avg
 
-        raise NotImplementedError(
-            "Weighing type {} not yet supported.".format(weighing_type)
-        )
+        if weighing_type == WeighingEnum.TIME:
+            _analysis = TimeWeighingAnalysis()
+        elif weighing_type == WeighingEnum.LENGTH:
+            _analysis = LengthWeighingAnalysis()
+        else:
+            raise NotImplementedError(
+                "Weighing type {} not yet supported.".format(weighing_type)
+            )
+
+        _analysis.avgspeed_dict = {
+            _road_type.config_value: _get_avgspeed_for_roadtype(gdf_graph, _road_type)
+            for _road_type in RoadTypeEnum
+        }
+
+        return _analysis

--- a/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_factory.py
+++ b/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_factory.py
@@ -20,7 +20,7 @@ class WeighingAnalysisFactory:
         if weighing_type == WeighingEnum.TIME:
             _analysis = TimeWeighingAnalysis(gdf_graph)
         elif weighing_type == WeighingEnum.LENGTH:
-            _analysis = LengthWeighingAnalysis()
+            _analysis = LengthWeighingAnalysis(gdf_graph)
         else:
             raise NotImplementedError(
                 "Weighing type {} not yet supported.".format(weighing_type)

--- a/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_factory.py
+++ b/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_factory.py
@@ -18,11 +18,10 @@ class WeighingAnalysisFactory:
         weighing_type: WeighingEnum, gdf_graph: gpd.GeoDataFrame | None
     ) -> WeighingAnalysisProtocol:
         if weighing_type == WeighingEnum.TIME:
-            _analysis = TimeWeighingAnalysis(gdf_graph)
-        elif weighing_type == WeighingEnum.LENGTH:
-            _analysis = LengthWeighingAnalysis(gdf_graph)
-        else:
-            raise NotImplementedError(
-                "Weighing type {} not yet supported.".format(weighing_type)
-            )
-        return _analysis
+            return TimeWeighingAnalysis(gdf_graph)
+        if weighing_type == WeighingEnum.LENGTH:
+            return LengthWeighingAnalysis(gdf_graph)
+
+        raise NotImplementedError(
+            "Weighing type {} not yet supported.".format(weighing_type)
+        )

--- a/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_protocol.py
+++ b/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_protocol.py
@@ -1,33 +1,25 @@
 from typing import Any, Protocol, runtime_checkable
 
-import geopandas as gpd
-
 
 @runtime_checkable
 class WeighingAnalysisProtocol(Protocol):
-    weighing_data: dict[str, Any]
-    avgspeed_dict: dict[str, float]
+    edge_data: dict[str, Any]
 
-    def calculate_value(self) -> float:
+    def calculate_current_value(self) -> float:
         """
-        Calculates the distance/time of the current `weighing_data` collection.
+        Calculates the current distance/time of the edge.
 
         Returns:
-            float: Single distance/time value.
+            float: Current distance/time value.
         """
 
     def calculate_alternative_value(self, alt_dist: float) -> float:
         """
-        Calculates alternative distances/times relative the current `weighing_data` collection.
+        Calculates the alternative distances/times of the edge.
 
         Args:
             alt_dist (float): Provided alternative distance/time.
 
         Returns:
             float: Corrected alternative distance/time value.
-        """
-
-    def extend_graph(self, gdf_graph: gpd.GeoDataFrame | dict) -> None:
-        """
-        Extends the provided graph with custom attributes.
         """

--- a/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_protocol.py
+++ b/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_protocol.py
@@ -7,23 +7,23 @@ import geopandas as gpd
 class WeighingAnalysisProtocol(Protocol):
     weighing_data: dict
 
-    def calculate_distance(self) -> float:
+    def calculate_value(self) -> float:
         """
-        Calculates the distance of the current `weighing_data` collection.
+        Calculates the distance/time of the current `weighing_data` collection.
 
         Returns:
-            float: Single distance value.
+            float: Single distance/time value.
         """
 
-    def calculate_alternative_distance(self, alt_dist: float) -> float:
+    def calculate_alternative_value(self, alt_dist: float) -> float:
         """
-        Calculates alternative distances relative the current `weighing_data` collection.
+        Calculates alternative distances/times relative the current `weighing_data` collection.
 
         Args:
-            alt_dist (float): Provided alternative distance.
+            alt_dist (float): Provided alternative distance/time.
 
         Returns:
-            float: Corrected alternative distance.
+            float: Corrected alternative distance/time value.
         """
 
     def extend_graph(self, gdf_graph: gpd.GeoDataFrame | dict) -> None:

--- a/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_protocol.py
+++ b/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_protocol.py
@@ -5,9 +5,10 @@ from typing import Any, Protocol, runtime_checkable
 class WeighingAnalysisProtocol(Protocol):
     edge_data: dict[str, Any]
 
-    def calculate_current_value(self) -> float:
+    def get_current_value(self) -> float:
         """
-        Calculates the current distance/time of the edge.
+        Gets the current distance/time of the edge.
+        If the edge has not time attribute, it is calculated and added to the edge.
 
         Returns:
             float: Current distance/time value.

--- a/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_protocol.py
+++ b/ra2ce/analysis/losses/weighing_analysis/weighing_analysis_protocol.py
@@ -1,11 +1,12 @@
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 import geopandas as gpd
 
 
 @runtime_checkable
 class WeighingAnalysisProtocol(Protocol):
-    weighing_data: dict
+    weighing_data: dict[str, Any]
+    avgspeed_dict: dict[str, float]
 
     def calculate_value(self) -> float:
         """

--- a/ra2ce/network/hazard/hazard_overlay.py
+++ b/ra2ce/network/hazard/hazard_overlay.py
@@ -460,7 +460,7 @@ class HazardOverlay:
             _hazard_crs != _gdf_crs
         ):  # Temporarily reproject the graph to the CRS of the hazard
             logging.warning(
-                "Hazard crs % and gdf crs %s are inconsistent, we try to reproject the gdf crs",
+                "Hazard crs %s and gdf crs %s are inconsistent, we try to reproject the gdf crs",
                 _hazard_crs,
                 _gdf_crs,
             )

--- a/ra2ce/network/networks.py
+++ b/ra2ce/network/networks.py
@@ -186,7 +186,7 @@ class Network:
                 )
                 time_value = None
             else:
-                time_value = (e[-1]["length"] / 1000) / e[-1]["avgspeed"]
+                time_value = (e[-1]["length"] * 1e-3) / e[-1]["avgspeed"]
             result[(e[0], e[1], e[2])] = {"time": time_value}
 
         return result

--- a/ra2ce/network/networks_utils.py
+++ b/ra2ce/network/networks_utils.py
@@ -1859,7 +1859,10 @@ def get_avgspeed_per_road_type(
         float: The average speed for that road type
     """
     _default_speed = 50
-    if not isinstance(gdf_graph, gpd.GeoDataFrame) or "higway" not in gdf_graph.columns:
+    if (
+        not isinstance(gdf_graph, gpd.GeoDataFrame)
+        or "highway" not in gdf_graph.columns
+    ):
         return _default_speed
 
     _avgspeed = gdf_graph[gdf_graph["highway"] == road_type.config_value]["avgspeed"]

--- a/ra2ce/network/networks_utils.py
+++ b/ra2ce/network/networks_utils.py
@@ -1858,6 +1858,10 @@ def get_avgspeed_per_road_type(
     Returns:
         float: The average speed for that road type
     """
+    _default_speed = 50
+    if not gdf_graph:
+        return _default_speed
+
     _avgspeed = gdf_graph[gdf_graph["highway"] == road_type.config_value]["avgspeed"]
     _avg = _avgspeed[_avgspeed > 0].mean()
     if _avg > 0:
@@ -1870,7 +1874,6 @@ def get_avgspeed_per_road_type(
         return _avg
 
     # If the graph has no average speed, return the default average speed
-    _default_speed = 50
     logging.warning(
         "No average speed found for road type %s. Using default speed of %s.",
         road_type,

--- a/ra2ce/network/networks_utils.py
+++ b/ra2ce/network/networks_utils.py
@@ -1849,6 +1849,7 @@ def get_avgspeed_per_road_type(
     Calculate the average speed of a graph per road type.
     If all edges of a certain road type have no average speed,
     the average speed of the whole graph is returned.
+    If the graph has no average speed on any edge, the default average speed is returned (== 50).
 
     Args:
         gdf_graph (gpd.GeoDataFrame): The graph
@@ -1861,13 +1862,21 @@ def get_avgspeed_per_road_type(
     _avg = _avgspeed[_avgspeed > 0].mean()
     if _avg > 0:
         return _avg
-    # If the average speed is not available,
-    # get the average speed of the whole graph
+
+    # If the average speed is not available, get the average speed of the whole graph
     _avgspeed = gdf_graph["avgspeed"]
     _avg = _avgspeed[_avgspeed > 0].mean()
     if _avg > 0:
         return _avg
-    return 50  # Default average speed
+
+    # If the graph has no average speed, return the default average speed
+    _default_speed = 50
+    logging.warning(
+        "No average speed found for road type %s. Using default speed of %s.",
+        road_type,
+        _default_speed,
+    )
+    return _default_speed  # Default average speed
 
 
 def fraction_flooded(line: LineString, hazard_map: str):

--- a/ra2ce/network/networks_utils.py
+++ b/ra2ce/network/networks_utils.py
@@ -1859,7 +1859,7 @@ def get_avgspeed_per_road_type(
         float: The average speed for that road type
     """
     _default_speed = 50
-    if not isinstance(gdf_graph, gpd.GeoDataFrame):
+    if not isinstance(gdf_graph, gpd.GeoDataFrame) or "higway" not in gdf_graph.columns:
         return _default_speed
 
     _avgspeed = gdf_graph[gdf_graph["highway"] == road_type.config_value]["avgspeed"]

--- a/ra2ce/network/networks_utils.py
+++ b/ra2ce/network/networks_utils.py
@@ -1843,7 +1843,7 @@ def assign_avg_speed(graph, avg_road_speed, road_type_col_name):
 
 
 def get_avgspeed_per_road_type(
-    gdf_graph: gpd.GeoDataFrame, road_type: RoadTypeEnum
+    gdf_graph: gpd.GeoDataFrame | None, road_type: RoadTypeEnum
 ) -> float:
     """
     Calculate the average speed of a graph per road type.
@@ -1859,7 +1859,7 @@ def get_avgspeed_per_road_type(
         float: The average speed for that road type
     """
     _default_speed = 50
-    if not gdf_graph:
+    if not isinstance(gdf_graph, gpd.GeoDataFrame):
         return _default_speed
 
     _avgspeed = gdf_graph[gdf_graph["highway"] == road_type.config_value]["avgspeed"]

--- a/tests/analysis/losses/weighing_analysis/test_length_weighing_analysis.py
+++ b/tests/analysis/losses/weighing_analysis/test_length_weighing_analysis.py
@@ -24,7 +24,7 @@ class TestLengthWeighingAnalysis:
 
     def test_calculate_distance(self, valid_analysis: LengthWeighingAnalysis):
         # 1. Run test
-        _calculated_distance = valid_analysis.calculate_current_value()
+        _calculated_distance = valid_analysis.get_current_value()
 
         # 2. Verify expectations.
         assert np.isnan(_calculated_distance)

--- a/tests/analysis/losses/weighing_analysis/test_length_weighing_analysis.py
+++ b/tests/analysis/losses/weighing_analysis/test_length_weighing_analysis.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from ra2ce.analysis.analysis_config_data.enums.weighing_enum import WeighingEnum
 from ra2ce.analysis.losses.weighing_analysis.length_weighing_analysis import (
     LengthWeighingAnalysis,
 )
@@ -12,7 +13,7 @@ from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
 class TestLengthWeighingAnalysis:
     def test_init(self):
         # 1. Define test data.
-        _analysis = LengthWeighingAnalysis()
+        _analysis = LengthWeighingAnalysis(None)
 
         # 2. Verify expectations.
         assert isinstance(_analysis, LengthWeighingAnalysis)
@@ -20,18 +21,37 @@ class TestLengthWeighingAnalysis:
 
     @pytest.fixture
     def valid_analysis(self) -> LengthWeighingAnalysis:
-        return LengthWeighingAnalysis()
+        _analysis = LengthWeighingAnalysis(None)
+        _analysis.edge_data = {WeighingEnum.TIME.config_value: 1, "avgspeed": 0.42}
+        return _analysis
 
     def test_calculate_distance(self, valid_analysis: LengthWeighingAnalysis):
-        # 1. Run test
-        _calculated_distance = valid_analysis.get_current_value()
+        # 1. Define test data.
+        _expected_distance = 420.0
+        _time = valid_analysis.edge_data[WeighingEnum.TIME.config_value]
 
-        # 2. Verify expectations.
-        assert np.isnan(_calculated_distance)
+        # 2. Run test
+        _calculated_distance = valid_analysis._calculate_distance(_time)
 
-    def test_calculate_alternative_distance(
-        self, valid_analysis: LengthWeighingAnalysis
-    ):
+        # 3. Verify expectations.
+        assert _calculated_distance == pytest.approx(_expected_distance)
+
+    def test_get_current_value(self, valid_analysis: LengthWeighingAnalysis):
+        # 1. Define test data.
+        _expected_distance = 420.0
+        _dist = valid_analysis.edge_data.get(WeighingEnum.LENGTH.config_value, 0)
+        assert not _dist
+
+        # 2. Run test
+        _current_distance = valid_analysis.get_current_value()
+
+        # 3. Verify expectations.
+        assert _current_distance == pytest.approx(_expected_distance)
+        assert valid_analysis.edge_data[
+            WeighingEnum.LENGTH.config_value
+        ] == pytest.approx(_expected_distance)
+
+    def test_calculate_alternative_value(self, valid_analysis: LengthWeighingAnalysis):
         # 1. Define test data.
         _alt_distance = 42
 
@@ -40,14 +60,3 @@ class TestLengthWeighingAnalysis:
 
         # 2. Verify expectations.
         assert _calculated_distance == _alt_distance
-
-    def test_extend_graph(self, valid_analysis: LengthWeighingAnalysis):
-        # 1. Define test data.
-        _graph_dict = dict(my_value=42)
-
-        # 2. Run test.
-        valid_analysis.extend_graph(_graph_dict)
-
-        # 3. Verify expectations
-        assert len(_graph_dict) == 1
-        assert _graph_dict["my_value"] == 42

--- a/tests/analysis/losses/weighing_analysis/test_length_weighing_analysis.py
+++ b/tests/analysis/losses/weighing_analysis/test_length_weighing_analysis.py
@@ -24,7 +24,7 @@ class TestLengthWeighingAnalysis:
 
     def test_calculate_distance(self, valid_analysis: LengthWeighingAnalysis):
         # 1. Run test
-        _calculated_distance = valid_analysis.calculate_value()
+        _calculated_distance = valid_analysis.calculate_current_value()
 
         # 2. Verify expectations.
         assert np.isnan(_calculated_distance)
@@ -36,9 +36,7 @@ class TestLengthWeighingAnalysis:
         _alt_distance = 42
 
         # 1. Run test
-        _calculated_distance = valid_analysis.calculate_alternative_value(
-            _alt_distance
-        )
+        _calculated_distance = valid_analysis.calculate_alternative_value(_alt_distance)
 
         # 2. Verify expectations.
         assert _calculated_distance == _alt_distance

--- a/tests/analysis/losses/weighing_analysis/test_length_weighing_analysis.py
+++ b/tests/analysis/losses/weighing_analysis/test_length_weighing_analysis.py
@@ -24,7 +24,7 @@ class TestLengthWeighingAnalysis:
 
     def test_calculate_distance(self, valid_analysis: LengthWeighingAnalysis):
         # 1. Run test
-        _calculated_distance = valid_analysis.calculate_distance()
+        _calculated_distance = valid_analysis.calculate_value()
 
         # 2. Verify expectations.
         assert np.isnan(_calculated_distance)
@@ -36,7 +36,7 @@ class TestLengthWeighingAnalysis:
         _alt_distance = 42
 
         # 1. Run test
-        _calculated_distance = valid_analysis.calculate_alternative_distance(
+        _calculated_distance = valid_analysis.calculate_alternative_value(
             _alt_distance
         )
 

--- a/tests/analysis/losses/weighing_analysis/test_time_weighing_analysis.py
+++ b/tests/analysis/losses/weighing_analysis/test_time_weighing_analysis.py
@@ -1,4 +1,3 @@
-import numpy as np
 import pytest
 
 from ra2ce.analysis.analysis_config_data.enums.weighing_enum import WeighingEnum
@@ -42,7 +41,7 @@ class TestTimeWeighingAnalysis:
         _expected_value = 1.0
 
         # 2. Run test
-        _calculated_distance = valid_analysis.calculate_distance()
+        _calculated_distance = valid_analysis.calculate_value()
 
         # 3. Verify expectations.
         assert _calculated_distance == pytest.approx(_expected_value)
@@ -55,9 +54,7 @@ class TestTimeWeighingAnalysis:
         _expected_time = 1.0
 
         # 2. Run test
-        _calculated_distance = valid_analysis.calculate_alternative_distance(
-            _alt_distance
-        )
+        _calculated_distance = valid_analysis.calculate_alternative_value(_alt_distance)
 
         # 3. Verify expectations.
         assert _calculated_distance == pytest.approx(_expected_value, rel=1e-2)

--- a/tests/analysis/losses/weighing_analysis/test_time_weighing_analysis.py
+++ b/tests/analysis/losses/weighing_analysis/test_time_weighing_analysis.py
@@ -41,7 +41,7 @@ class TestTimeWeighingAnalysis:
         _expected_value = 1.0
 
         # 2. Run test
-        _calculated_distance = valid_analysis.calculate_value()
+        _calculated_distance = valid_analysis.calculate_current_value()
 
         # 3. Verify expectations.
         assert _calculated_distance == pytest.approx(_expected_value)

--- a/tests/analysis/losses/weighing_analysis/test_time_weighing_analysis.py
+++ b/tests/analysis/losses/weighing_analysis/test_time_weighing_analysis.py
@@ -23,7 +23,7 @@ class TestTimeWeighingAnalysis:
     def valid_analysis(self) -> TimeWeighingAnalysis:
         _analysis = TimeWeighingAnalysis()
         _weighing_data_dict = {"length": 420, "avgspeed": 0.42}
-        _analysis.weighing_data = _weighing_data_dict
+        _analysis.edge_data = _weighing_data_dict
         return _analysis
 
     def test_calculate_time(self, valid_analysis: TimeWeighingAnalysis):
@@ -41,7 +41,7 @@ class TestTimeWeighingAnalysis:
         _expected_value = 1.0
 
         # 2. Run test
-        _calculated_distance = valid_analysis.calculate_current_value()
+        _calculated_distance = valid_analysis.get_current_value()
 
         # 3. Verify expectations.
         assert _calculated_distance == pytest.approx(_expected_value)

--- a/tests/analysis/losses/weighing_analysis/test_time_weighing_analysis.py
+++ b/tests/analysis/losses/weighing_analysis/test_time_weighing_analysis.py
@@ -12,65 +12,51 @@ from ra2ce.analysis.losses.weighing_analysis.weighing_analysis_protocol import (
 class TestTimeWeighingAnalysis:
     def test_init(self):
         # 1. Define test data.
-        _analysis = TimeWeighingAnalysis()
+        _analysis = TimeWeighingAnalysis(None)
 
         # 2. Verify expectations.
         assert isinstance(_analysis, TimeWeighingAnalysis)
         assert isinstance(_analysis, WeighingAnalysisProtocol)
-        assert _analysis.time_list == []
 
     @pytest.fixture
     def valid_analysis(self) -> TimeWeighingAnalysis:
-        _analysis = TimeWeighingAnalysis()
-        _weighing_data_dict = {"length": 420, "avgspeed": 0.42}
-        _analysis.edge_data = _weighing_data_dict
+        _analysis = TimeWeighingAnalysis(None)
+        _analysis.edge_data = {WeighingEnum.LENGTH.config_value: 420, "avgspeed": 0.42}
         return _analysis
 
     def test_calculate_time(self, valid_analysis: TimeWeighingAnalysis):
         # 1. Define test data.
-        _expected_value = 1.0
+        _expected_time = 1.0
+        _dist = valid_analysis.edge_data[WeighingEnum.LENGTH.config_value]
 
         # 2. Run test.
-        _calculated_time = valid_analysis._calculate_time()
+        _calculated_time = valid_analysis._calculate_time(_dist)
 
         # 3. Verify expectations.
-        assert _calculated_time == pytest.approx(_expected_value)
+        assert _calculated_time == pytest.approx(_expected_time)
 
-    def test_calculate_distance(self, valid_analysis: TimeWeighingAnalysis):
+    def test_get_current_value(self, valid_analysis: TimeWeighingAnalysis):
         # 1. Define test data.
-        _expected_value = 1.0
+        _expected_time = 1.0
+        _time = valid_analysis.edge_data.get(WeighingEnum.TIME.config_value, 0)
+        assert not _time
 
         # 2. Run test
-        _calculated_distance = valid_analysis.get_current_value()
+        _current_time = valid_analysis.get_current_value()
 
         # 3. Verify expectations.
-        assert _calculated_distance == pytest.approx(_expected_value)
-        assert valid_analysis.time_list == [_calculated_distance]
+        assert _current_time == pytest.approx(_expected_time)
+        assert valid_analysis.edge_data[
+            WeighingEnum.TIME.config_value
+        ] == pytest.approx(_expected_time)
 
-    def test_calculate_alternative_distance(self, valid_analysis: TimeWeighingAnalysis):
+    def test_calculate_alternative_value(self, valid_analysis: TimeWeighingAnalysis):
         # 1. Define test data.
         _alt_distance = 240
-        _expected_value = 0.57
-        _expected_time = 1.0
+        _expected_time = 0.57
 
         # 2. Run test
-        _calculated_distance = valid_analysis.calculate_alternative_value(_alt_distance)
+        _calculated_time = valid_analysis.calculate_alternative_value(_alt_distance)
 
         # 3. Verify expectations.
-        assert _calculated_distance == pytest.approx(_expected_value, rel=1e-2)
-        assert len(valid_analysis.time_list) == 1
-        assert valid_analysis.time_list[-1] == pytest.approx(_expected_time)
-
-    def test_extend_graph(self, valid_analysis: TimeWeighingAnalysis):
-        # 1. Define test data.
-        _graph_dict = dict(my_value=42)
-        _time_list = [4.2]
-        valid_analysis.time_list = _time_list
-
-        # 2. Run test.
-        valid_analysis.extend_graph(_graph_dict)
-
-        # 3. Verify expectations
-        assert len(_graph_dict) == 2
-        assert _graph_dict["my_value"] == 42
-        assert _graph_dict[WeighingEnum.TIME.config_value] == _time_list
+        assert _calculated_time == pytest.approx(_expected_time, rel=1e-2)

--- a/tests/analysis/losses/weighing_analysis/test_weighing_analysis_factory.py
+++ b/tests/analysis/losses/weighing_analysis/test_weighing_analysis_factory.py
@@ -17,7 +17,7 @@ class TestWeighingAnalysisFactory:
         [pytest.param(we) for we in WeighingEnum if we not in _unsupported_enums],
     )
     def test_get_analysis_with_valid_enum(self, valid_enum: WeighingEnum):
-        _analysis = WeighingAnalysisFactory.get_analysis(valid_enum)
+        _analysis = WeighingAnalysisFactory.get_analysis(valid_enum, None)
 
         assert isinstance(_analysis, WeighingAnalysisProtocol)
 
@@ -28,7 +28,7 @@ class TestWeighingAnalysisFactory:
     def test_get_analysis_with_unsupported_enum(self, valid_enum: WeighingEnum):
         # 2. Run test.
         with pytest.raises(NotImplementedError) as exc_err:
-            WeighingAnalysisFactory.get_analysis(valid_enum)
+            WeighingAnalysisFactory.get_analysis(valid_enum, None)
 
         # 3. Verify expectations.
         assert str(exc_err.value) == "Weighing type {} not yet supported.".format(
@@ -41,7 +41,7 @@ class TestWeighingAnalysisFactory:
 
         # 2. Run test.
         with pytest.raises(NotImplementedError) as exc_err:
-            WeighingAnalysisFactory.get_analysis(_invalid_enum)
+            WeighingAnalysisFactory.get_analysis(_invalid_enum, None)
 
         # 3. Verify expectations.
         assert str(exc_err.value) == "Weighing type {} not yet supported.".format(


### PR DESCRIPTION
## Issue addressed
Solves #433

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [ ] I HAVE discussed my solution with (other) members of the RA2CE team.

## What has been done?
In several cases some edges have `avgspeed == None` and `time == 0`. To give valid results:
* the mean avgspeed of all edges of the same road type with a valid avgspeed (>0) is taken;
* if none of the edges of the same road type have a valid avgspeed, the mean avgspeed of all edges in the network with valid avgspeed (>0) is taken;
* if none of the edges in the network has a valid avgspeed, a default value (hardcoded 50) is returned.
  * this could be moved to the config and defined per road type later on.

### Checklist
- [x] Code is formatted using our custom `black` and `isort` definitions.
- [x] Tests are either added or updated.
- [x] Branch is up to date with `master`.
- [ ] Updated documentation if needed.

## Additional Notes (optional)
* Calculate current time/distance value before removing edges from the graph to ensure all edges have the needed attributes to calculate the dijkstra_path with the right weighing.
* Removed `extend_gdf` and add current values (time/distance) after the loop from the list.
* Refactored the analysers:
  * implified and more robust logic;
  * more logical variable and methods names;
  * rounding the original and alternative value.
* Use math.nan instead of np.nan where possible.
