### PR TITLE
Feat/489 adjust traffic intensities to per give traffic period

### DIFF
--- a/ra2ce/analysis/losses/losses_base.py
+++ b/ra2ce/analysis/losses/losses_base.py
@@ -78,7 +78,6 @@ class LossesBase(AnalysisLossesProtocol, ABC):
 
         self.part_of_day: PartOfDayEnum = self.analysis.part_of_day
         self.analysis_type = self.analysis.analysis
-        self.hours_per_day: float = 24  # we consider here only daily losses
         self.production_loss_per_capita_per_hour = (
             self.analysis.production_loss_per_capita_per_hour
         )
@@ -412,11 +411,8 @@ class LossesBase(AnalysisLossesProtocol, ABC):
         )
 
         for trip_type in self.trip_purposes:
-            intensity_trip_type = (
-                self.intensities.calculate_intensity(
-                    vlh_row[self.link_id], self.part_of_day, trip_type
-                )
-                / self.hours_per_day
+            intensity_trip_type = self.intensities.calculate_intensity(
+                vlh_row[self.link_id], self.part_of_day, trip_type
             )
 
             occupancy_trip_type = self.values_of_time.get_occupants(trip_type)
@@ -463,11 +459,8 @@ class LossesBase(AnalysisLossesProtocol, ABC):
 
         # get vlh_trip_type_event
         for trip_type in self.trip_purposes:
-            intensity_trip_type = (
-                self.intensities.calculate_intensity(
-                    vlh_row[self.link_id], self.part_of_day, trip_type
-                )
-                / self.hours_per_day
+            intensity_trip_type = self.intensities.calculate_intensity(
+                vlh_row[self.link_id], self.part_of_day, trip_type
             )
 
             vot_trip_type = self.values_of_time.get_value_of_time(trip_type)

--- a/ra2ce/analysis/losses/traffic_intensities/traffic_intensities.py
+++ b/ra2ce/analysis/losses/traffic_intensities/traffic_intensities.py
@@ -28,7 +28,7 @@ class TrafficIntensities:
     """
 
     link_id: list[int | tuple[int, int]] = field(default_factory=list)
-    intensities: dict[tuple[PartOfDayEnum, TripPurposeEnum], list[int]] = field(
+    intensities: dict[tuple[PartOfDayEnum, TripPurposeEnum], list[float]] = field(
         default_factory=dict
     )
 
@@ -37,7 +37,7 @@ class TrafficIntensities:
         link_id: int | tuple[int, int],
         part_of_day: PartOfDayEnum,
         trip_purpose: TripPurposeEnum,
-    ) -> int:
+    ) -> float:
         """
         Calculate the traffic intensity for a specific link
         for a specific part of day for a specific trip purpose.
@@ -51,7 +51,7 @@ class TrafficIntensities:
             trip_purpose (TripPurposeEnum): Trip purpose
 
         Returns:
-            int: The intensity for that (set of) link(s)
+            float: The intensity for the (set of) link(s)
         """
         if isinstance(link_id, tuple):
             return max(

--- a/ra2ce/analysis/losses/traffic_intensities/traffic_intensities.py
+++ b/ra2ce/analysis/losses/traffic_intensities/traffic_intensities.py
@@ -23,7 +23,8 @@ from ra2ce.analysis.analysis_config_data.enums.trip_purpose_enum import TripPurp
 @dataclass(kw_only=True)
 class TrafficIntensities:
     """
-    Class to store the traffic intensities per day for different trip types.
+    Class to store the traffic intensities per hour for a specific part of day
+    for different trip purposes.
     """
 
     link_id: list[int | tuple[int, int]] = field(default_factory=list)
@@ -38,8 +39,8 @@ class TrafficIntensities:
         trip_purpose: TripPurposeEnum,
     ) -> int:
         """
-        Calculate the traffic intensity per part of day for a specific link
-        for a trip purpose.
+        Calculate the traffic intensity for a specific link
+        for a specific part of day for a specific trip purpose.
 
         For a simplified graph, the link_id could be a tuple of link_ids.
         In that case the maximum intensity of the links is returned.

--- a/ra2ce/analysis/losses/traffic_intensities/traffic_intensities_reader.py
+++ b/ra2ce/analysis/losses/traffic_intensities/traffic_intensities_reader.py
@@ -30,7 +30,7 @@ from ra2ce.analysis.losses.traffic_intensities.traffic_intensities import (
 
 class TrafficIntensitiesReader(LossesInputDataReaderBase):
     """
-    Class to read the traffic intensities per part of day from a csv file.
+    Class to read the traffic intensities per hour per part of day and trip purpose from a csv file.
     """
 
     csv_columns = []
@@ -44,6 +44,7 @@ class TrafficIntensitiesReader(LossesInputDataReaderBase):
         _traffic_intensities = TrafficIntensities()
         for col in df:
             if col == self.csv_columns[0]:
+                # Link id column
                 _traffic_intensities.link_id = df[col].tolist()
                 continue
             _col_parts = col.split("_")

--- a/tests/analysis/losses/traffic_intensities/conftest.py
+++ b/tests/analysis/losses/traffic_intensities/conftest.py
@@ -18,21 +18,21 @@ def get_traffic_intensities_csv_filepath() -> Iterator[Path]:
 
 @pytest.fixture(name="traffic_intensities_data")
 def get_traffic_intensities_data() -> Iterator[
-    dict[tuple[PartOfDayEnum, TripPurposeEnum], list[int]]
+    dict[tuple[PartOfDayEnum, TripPurposeEnum], list[float]]
 ]:
     """
     Get traffic intensities data for testing (links 1:5).
 
     Yields:
-        Iterator[dict[tuple[PartOfDayEnum, RoadTypeEnum], list[int]]]: Traffic intensities data.
+        Iterator[dict[tuple[PartOfDayEnum, RoadTypeEnum], list[float]]]: Traffic intensities data.
     """
     yield {
-        (PartOfDayEnum.EVENING, TripPurposeEnum.FREIGHT): [0, 0, 0, 0, 0],
-        (PartOfDayEnum.EVENING, TripPurposeEnum.COMMUTE): [10, 2, 8, 20, 4],
-        (PartOfDayEnum.EVENING, TripPurposeEnum.BUSINESS): [20, 5, 7, 10, 8],
-        (PartOfDayEnum.EVENING, TripPurposeEnum.OTHER): [0, 0, 0, 0, 0],
-        (PartOfDayEnum.DAY, TripPurposeEnum.FREIGHT): [0, 0, 0, 0, 0],
-        (PartOfDayEnum.DAY, TripPurposeEnum.COMMUTE): [10, 2, 8, 20, 4],
-        (PartOfDayEnum.DAY, TripPurposeEnum.BUSINESS): [20, 5, 7, 10, 8],
-        (PartOfDayEnum.DAY, TripPurposeEnum.OTHER): [0, 0, 0, 0, 0],
+        (PartOfDayEnum.EVENING, TripPurposeEnum.FREIGHT): [0.0, 0.0, 0.0, 0.0, 0.0],
+        (PartOfDayEnum.EVENING, TripPurposeEnum.COMMUTE): [10.0, 2.0, 8.0, 20.0, 4.0],
+        (PartOfDayEnum.EVENING, TripPurposeEnum.BUSINESS): [20.0, 5.0, 7.0, 10.0, 8.0],
+        (PartOfDayEnum.EVENING, TripPurposeEnum.OTHER): [0.0, 0.0, 0.0, 0.0, 0.0],
+        (PartOfDayEnum.DAY, TripPurposeEnum.FREIGHT): [0.0, 0.0, 0.0, 0.0, 0.0],
+        (PartOfDayEnum.DAY, TripPurposeEnum.COMMUTE): [10.0, 2.0, 8.0, 20.0, 4.0],
+        (PartOfDayEnum.DAY, TripPurposeEnum.BUSINESS): [20.0, 5.0, 7.0, 10.0, 8.0],
+        (PartOfDayEnum.DAY, TripPurposeEnum.OTHER): [0.0, 0.0, 0.0, 0.0, 0.0],
     }

--- a/tests/analysis/losses/traffic_intensities/test_traffic_intensities.py
+++ b/tests/analysis/losses/traffic_intensities/test_traffic_intensities.py
@@ -11,9 +11,9 @@ class TestTrafficIntensities:
     @pytest.mark.parametrize(
         "link_id, expected",
         [
-            pytest.param(2, 5, id="from int (link 2)"),
-            pytest.param(5, 8, id="from int (link 5)"),
-            pytest.param((2, 5), 8, id="from tuple[int]"),
+            pytest.param(2, 5.0, id="from int (link 2)"),
+            pytest.param(5, 8.0, id="from int (link 5)"),
+            pytest.param((2, 5), 8.0, id="from tuple[int]"),
         ],
     )
     def test_calculate_traffic_intensity(
@@ -22,7 +22,7 @@ class TestTrafficIntensities:
             tuple[PartOfDayEnum, TripPurposeEnum], list[int]
         ],
         link_id: int | tuple[int, int],
-        expected: int,
+        expected: float,
     ):
         # 1. Define test data
         _traffic_intensities = TrafficIntensities(link_id=list(range(1, 6)))
@@ -40,4 +40,4 @@ class TestTrafficIntensities:
         )
 
         # 3. Verify expectations
-        assert _result == expected
+        assert _result == pytest.approx(expected)

--- a/tests/analysis/losses/traffic_intensities/test_traffic_intensities_reader.py
+++ b/tests/analysis/losses/traffic_intensities/test_traffic_intensities_reader.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from ra2ce.analysis.analysis_config_data.enums.part_of_day_enum import PartOfDayEnum
 from ra2ce.analysis.analysis_config_data.enums.trip_purpose_enum import TripPurposeEnum
 from ra2ce.analysis.losses.losses_input_data_reader_base import (
@@ -41,6 +43,6 @@ class TestTimeValuesReader:
         assert isinstance(_traffic_intensities, TrafficIntensities)
         for _key in traffic_intensities_data:
             assert _key in _traffic_intensities.intensities
-            assert (
-                traffic_intensities_data[_key] == _traffic_intensities.intensities[_key]
+            assert traffic_intensities_data[_key] == pytest.approx(
+                _traffic_intensities.intensities[_key]
             )


### PR DESCRIPTION
## Issue addressed
Add to #489 

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [x] I HAVE discussed my solution with (other) members of the RA2CE team.

## What has been done?
* Assume traffic intensities are per give time period
  * Default traffic period is day
  * If the user chose a custom traffic period they need to provide the `hours_per_traffic_period`
* Assume they are of type float and not int

### Checklist
- [x] Code is formatted using our custom `black` and `isort` definitions.
- [x] Tests are either added or updated.
- [ ] Branch is up to date with `master`.
- [ ] Updated documentation if needed.

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
