### PR TITLE
ci: enforced `conda-forge` as channel for all dependencies

### DIFF
--- a/.config/tc_environment.yml
+++ b/.config/tc_environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python=3.10
+  - conda-forge::python=3.10
   - conda-forge::gdal=3.5.1
   - conda-forge::pandoc
-  - teamcity-messages
+  - conda-forge::teamcity-messages


### PR DESCRIPTION
## Issue addressed
Solves compliance of Deltares policy with `conda` packages.

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [x] I HAVE discussed my solution with (other) members of the RA2CE team.

## What has been done?
Enforced the use of `conda-forge::` as channel for installing the required dependencies.

### Checklist
- [x] Code is formatted using our custom `black` and `isort` definitions.
- [x] Tests are either added or updated.
- [x] Branch is up to date with `master`.
- [x] Updated documentation if needed.
