### PR TITLE
chore: Removed intermediate export logic

### DIFF
--- a/ra2ce/analysis/analysis_base.py
+++ b/ra2ce/analysis/analysis_base.py
@@ -34,6 +34,18 @@ class AnalysisBase(ABC, AnalysisProtocol):
     the `AnalysisProtocol`.
     """
 
+    def _get_analysis_result(
+        self, gdf_result: GeoDataFrame, custom_name: str
+    ) -> AnalysisResult:
+        _ar = AnalysisResult(
+            analysis_result=gdf_result,
+            analysis_config=self.analysis,
+            output_path=self.output_path,
+        )
+        if custom_name:
+            _ar.analysis_name = custom_name
+        return _ar
+
     def generate_result_wrapper(
         self, *analysis_result: GeoDataFrame
     ) -> AnalysisResultWrapper:
@@ -48,13 +60,8 @@ class AnalysisBase(ABC, AnalysisProtocol):
             AnalysisResultWrapper: Wrapping result with configuration details.
         """
 
-        def get_analysis_result(gdf_result: GeoDataFrame) -> AnalysisResult:
-            return AnalysisResult(
-                analysis_result=gdf_result,
-                analysis_config=self.analysis,
-                output_path=self.output_path,
-            )
-
         return AnalysisResultWrapper(
-            results_collection=list(map(get_analysis_result, analysis_result))
+            results_collection=[
+                self._get_analysis_result(_ar, "") for _ar in analysis_result
+            ]
         )

--- a/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
+++ b/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
@@ -16,6 +16,7 @@ from ra2ce.network.hazard.hazard_names import HazardNames
 from ra2ce.network.network_config_data.network_config_data import (
     OriginsDestinationsSection,
 )
+from ra2ce.network.networks_utils import get_nodes_and_edges_from_origin_graph
 
 
 class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
@@ -62,7 +63,7 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
         analyzer = OriginClosestDestination(self._analysis_input)
         if self.analysis.calculate_route_without_disruption:
             (
-                _,
+                _base_graph,
                 opt_routes_without_hazard,
                 destinations,
             ) = analyzer.optimal_route_origin_closest_destination()
@@ -86,7 +87,7 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
                 )
         else:
             (
-                _,
+                _base_graph,
                 origins,
                 destinations,
                 agg_results,
@@ -94,6 +95,7 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
             ) = analyzer.multi_link_origin_closest_destination()
             opt_routes_without_hazard = GeoDataFrame()
 
+        _nodes_graph, _edges_graph = get_nodes_and_edges_from_origin_graph(base_graph)
         _analysis_result_wrapper = AnalysisResultWrapper(
             results_collection=[
                 get_analysis_result(origins, "_origins"),
@@ -104,6 +106,8 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
                 get_analysis_result(
                     opt_routes_with_hazard, "_optimal_routes_with_hazard"
                 ),
+                get_analysis_result(_nodes_graph, "_results_nodes"),
+                get_analysis_result(_edges_graph, "_results_edges"),
             ]
         )
 

--- a/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
+++ b/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
@@ -85,15 +85,25 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
 
         _nodes_graph, _edges_graph = get_nodes_and_edges_from_origin_graph(_base_graph)
         _base_name = self.analysis.name.replace(" ", "_")
+        _opt_without_hazard = self._get_analysis_result(
+            opt_routes_without_hazard, _base_name + "_optimal_routes_without_hazard"
+        )
+        _opt_with_hazard = self._get_analysis_result(
+            opt_routes_with_hazard, _base_name + "_optimal_routes_with_hazard"
+        )
+
         _analysis_result_wrapper = AnalysisResultWrapper(
             results_collection=[
                 self._get_analysis_result(origins, _base_name + "_origins"),
                 self._get_analysis_result(destinations, _base_name + "_destinations"),
-                self._get_analysis_result(destinations, _base_name + "_optimal_routes"),
                 self._get_analysis_result(_nodes_graph, _base_name + "_results_nodes"),
                 self._get_analysis_result(_edges_graph, _base_name + "_results_edges"),
+                _opt_without_hazard,
+                _opt_with_hazard,
             ]
         )
+
+        # Legacy code, previously only done to export to CSV.
         if not opt_routes_with_hazard.empty:
             _analysis_result_wrapper.results_collection.append(
                 self._get_analysis_result(

--- a/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
+++ b/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
@@ -73,7 +73,7 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
                 opt_routes_with_hazard = GeoDataFrame(data=None)
             else:
                 (
-                    base_graph,
+                    _base_graph,
                     origins,
                     destinations,
                     agg_results,
@@ -95,21 +95,24 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
             ) = analyzer.multi_link_origin_closest_destination()
             opt_routes_without_hazard = GeoDataFrame()
 
-        _nodes_graph, _edges_graph = get_nodes_and_edges_from_origin_graph(base_graph)
+        _nodes_graph, _edges_graph = get_nodes_and_edges_from_origin_graph(_base_graph)
         _analysis_result_wrapper = AnalysisResultWrapper(
             results_collection=[
                 get_analysis_result(origins, "_origins"),
                 get_analysis_result(destinations, "_destinations"),
-                get_analysis_result(
-                    opt_routes_without_hazard, "_optimal_routes_without_hazard"
-                ),
-                get_analysis_result(
-                    opt_routes_with_hazard, "_optimal_routes_with_hazard"
-                ),
+                get_analysis_result(destinations, "_optimal_routes"),
                 get_analysis_result(_nodes_graph, "_results_nodes"),
                 get_analysis_result(_edges_graph, "_results_edges"),
             ]
         )
+        if not opt_routes_with_hazard.empty:
+            _analysis_result_wrapper.results_collection.append(
+                get_analysis_result(opt_routes_without_hazard, "_optimal_routes")
+            )
+        if not opt_routes_without_hazard.empty:
+            _analysis_result_wrapper.results_collection.append(
+                get_analysis_result(opt_routes_with_hazard, "_optimal_routes")
+            )
 
         if self.graph_file_hazard.file is not None:
             agg_results.to_excel(

--- a/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
+++ b/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
@@ -104,17 +104,14 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
         )
 
         # Legacy code, previously only done to export to CSV.
-        if not opt_routes_with_hazard.empty:
-            _analysis_result_wrapper.results_collection.append(
-                self._get_analysis_result(
-                    opt_routes_without_hazard, _base_name + "_optimal_routes"
-                )
-            )
+        _opt_routes_name = _base_name + "_optimal_routes"
         if not opt_routes_without_hazard.empty:
             _analysis_result_wrapper.results_collection.append(
-                self._get_analysis_result(
-                    opt_routes_with_hazard, _base_name + "_optimal_routes"
-                )
+                self._get_analysis_result(opt_routes_with_hazard, _opt_routes_name)
+            )
+        if not opt_routes_with_hazard.empty:
+            _analysis_result_wrapper.results_collection.append(
+                self._get_analysis_result(opt_routes_without_hazard, _opt_routes_name)
             )
 
         if self.graph_file_hazard.file is not None:

--- a/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
+++ b/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
@@ -85,21 +85,19 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
 
         _nodes_graph, _edges_graph = get_nodes_and_edges_from_origin_graph(_base_graph)
         _base_name = self.analysis.name.replace(" ", "_")
-        _opt_without_hazard = self._get_analysis_result(
-            opt_routes_without_hazard, _base_name + "_optimal_routes_without_hazard"
-        )
-        _opt_with_hazard = self._get_analysis_result(
-            opt_routes_with_hazard, _base_name + "_optimal_routes_with_hazard"
-        )
-
         _analysis_result_wrapper = AnalysisResultWrapper(
             results_collection=[
                 self._get_analysis_result(origins, _base_name + "_origins"),
                 self._get_analysis_result(destinations, _base_name + "_destinations"),
                 self._get_analysis_result(_nodes_graph, _base_name + "_results_nodes"),
                 self._get_analysis_result(_edges_graph, _base_name + "_results_edges"),
-                _opt_without_hazard,
-                _opt_with_hazard,
+                self._get_analysis_result(
+                    opt_routes_without_hazard,
+                    _base_name + "_optimal_routes_without_hazard",
+                ),
+                self._get_analysis_result(
+                    opt_routes_with_hazard, _base_name + "_optimal_routes_with_hazard"
+                ),
             ]
         )
 

--- a/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
+++ b/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
@@ -47,17 +47,6 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
         self._analysis_input = analysis_input
 
     def execute(self) -> AnalysisResultWrapper:
-        def get_analysis_result(
-            gdf_result: GeoDataFrame, suffix_name: str
-        ) -> AnalysisResult:
-            _ar = AnalysisResult(
-                analysis_result=gdf_result,
-                analysis_config=self.analysis,
-                output_path=self.output_path,
-            )
-            _ar.analysis_name = self.analysis.name.replace(" ", "_") + suffix_name
-            return _ar
-
         _output_path = self.output_path.joinpath(self.analysis.analysis.config_value)
 
         analyzer = OriginClosestDestination(self._analysis_input)
@@ -96,22 +85,27 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
             opt_routes_without_hazard = GeoDataFrame()
 
         _nodes_graph, _edges_graph = get_nodes_and_edges_from_origin_graph(_base_graph)
+        _base_name = self.analysis.name.replace(" ", "_")
         _analysis_result_wrapper = AnalysisResultWrapper(
             results_collection=[
-                get_analysis_result(origins, "_origins"),
-                get_analysis_result(destinations, "_destinations"),
-                get_analysis_result(destinations, "_optimal_routes"),
-                get_analysis_result(_nodes_graph, "_results_nodes"),
-                get_analysis_result(_edges_graph, "_results_edges"),
+                self._get_analysis_result(origins, _base_name + "_origins"),
+                self._get_analysis_result(destinations, _base_name + "_destinations"),
+                self._get_analysis_result(destinations, _base_name + "_optimal_routes"),
+                self._get_analysis_result(_nodes_graph, _base_name + "_results_nodes"),
+                self._get_analysis_result(_edges_graph, _base_name + "_results_edges"),
             ]
         )
         if not opt_routes_with_hazard.empty:
             _analysis_result_wrapper.results_collection.append(
-                get_analysis_result(opt_routes_without_hazard, "_optimal_routes")
+                self._get_analysis_result(
+                    opt_routes_without_hazard, _base_name + "_optimal_routes"
+                )
             )
         if not opt_routes_without_hazard.empty:
             _analysis_result_wrapper.results_collection.append(
-                get_analysis_result(opt_routes_with_hazard, "_optimal_routes")
+                self._get_analysis_result(
+                    opt_routes_with_hazard, _base_name + "_optimal_routes"
+                )
             )
 
         if self.graph_file_hazard.file is not None:

--- a/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
+++ b/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
@@ -7,7 +7,6 @@ from ra2ce.analysis.analysis_config_data.analysis_config_data import (
     AnalysisSectionLosses,
 )
 from ra2ce.analysis.analysis_input_wrapper import AnalysisInputWrapper
-from ra2ce.analysis.analysis_result.analysis_result import AnalysisResult
 from ra2ce.analysis.analysis_result.analysis_result_wrapper import AnalysisResultWrapper
 from ra2ce.analysis.losses.analysis_losses_protocol import AnalysisLossesProtocol
 from ra2ce.analysis.losses.origin_closest_destination import OriginClosestDestination

--- a/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
+++ b/ra2ce/analysis/losses/multi_link_origin_closest_destination.py
@@ -7,6 +7,7 @@ from ra2ce.analysis.analysis_config_data.analysis_config_data import (
     AnalysisSectionLosses,
 )
 from ra2ce.analysis.analysis_input_wrapper import AnalysisInputWrapper
+from ra2ce.analysis.analysis_result.analysis_result import AnalysisResult
 from ra2ce.analysis.analysis_result.analysis_result_wrapper import AnalysisResultWrapper
 from ra2ce.analysis.losses.analysis_losses_protocol import AnalysisLossesProtocol
 from ra2ce.analysis.losses.origin_closest_destination import OriginClosestDestination
@@ -15,8 +16,6 @@ from ra2ce.network.hazard.hazard_names import HazardNames
 from ra2ce.network.network_config_data.network_config_data import (
     OriginsDestinationsSection,
 )
-from ra2ce.network.networks_utils import graph_to_gpkg
-from ra2ce.ra2ce_logger import logging
 
 
 class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
@@ -46,56 +45,24 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
         self.file_id = analysis_input.file_id
         self._analysis_input = analysis_input
 
-    def _save_gdf(self, gdf: GeoDataFrame, save_path: Path) -> None:
-        """Takes in a geodataframe object and outputs shapefiles at the paths indicated by edge_shp and node_shp
-
-        Arguments:
-            gdf [geodataframe]: geodataframe object to be converted
-            save_path [str]: output path including extension for edges shapefile
-        Returns:
-            None
-        """
-        # save to shapefile
-        gdf.crs = "epsg:4326"  # TODO: decide if this should be variable with e.g. an output_crs configured
-
-        for col in gdf.columns:
-            if gdf[col].dtype == object and col != gdf.geometry.name:
-                gdf[col] = gdf[col].astype(str)
-
-        if save_path.exists():
-            save_path.unlink()
-        gdf.to_file(save_path, driver="GPKG")
-        logging.info("Results saved to: {}".format(save_path))
-
     def execute(self) -> AnalysisResultWrapper:
-        def _save_gpkg_analysis(
-            base_graph,
-            to_save_gdf: list[GeoDataFrame],
-            to_save_gdf_names: list[str],
-        ):
-            for to_save, save_name in zip(to_save_gdf, to_save_gdf_names):
-                if not to_save.empty:
-                    gpkg_path = _output_path.joinpath(
-                        self.analysis.name.replace(" ", "_") + f"_{save_name}.gpkg"
-                    )
-                    self._save_gdf(to_save, gpkg_path)
-
-            # Save the Graph
-            gpkg_path_nodes = _output_path.joinpath(
-                self.analysis.name.replace(" ", "_") + "_results_nodes.gpkg"
+        def get_analysis_result(
+            gdf_result: GeoDataFrame, suffix_name: str
+        ) -> AnalysisResult:
+            _ar = AnalysisResult(
+                analysis_result=gdf_result,
+                analysis_config=self.analysis,
+                output_path=self.output_path,
             )
-            gpkg_path_edges = _output_path.joinpath(
-                self.analysis.name.replace(" ", "_") + "_results_edges.gpkg"
-            )
-            graph_to_gpkg(base_graph, gpkg_path_edges, gpkg_path_nodes)
+            _ar.analysis_name = self.analysis.name.replace(" ", "_") + suffix_name
+            return _ar
 
         _output_path = self.output_path.joinpath(self.analysis.analysis.config_value)
 
         analyzer = OriginClosestDestination(self._analysis_input)
-
         if self.analysis.calculate_route_without_disruption:
             (
-                base_graph,
+                _,
                 opt_routes_without_hazard,
                 destinations,
             ) = analyzer.optimal_route_origin_closest_destination()
@@ -119,7 +86,7 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
                 )
         else:
             (
-                base_graph,
+                _,
                 origins,
                 destinations,
                 agg_results,
@@ -127,40 +94,18 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
             ) = analyzer.multi_link_origin_closest_destination()
             opt_routes_without_hazard = GeoDataFrame()
 
-        if self.analysis.save_gpkg:
-            # Save the GeoDataFrames
-            to_save_gdf = [
-                origins,
-                destinations,
-                opt_routes_without_hazard,
-                opt_routes_with_hazard,
+        _analysis_result_wrapper = AnalysisResultWrapper(
+            results_collection=[
+                get_analysis_result(origins, "_origins"),
+                get_analysis_result(destinations, "_destinations"),
+                get_analysis_result(
+                    opt_routes_without_hazard, "_optimal_routes_without_hazard"
+                ),
+                get_analysis_result(
+                    opt_routes_with_hazard, "_optimal_routes_with_hazard"
+                ),
             ]
-            to_save_gdf_names = [
-                "origins",
-                "destinations",
-                "optimal_routes_without_hazard",
-                "optimal_routes_with_hazard",
-            ]
-            _save_gpkg_analysis(base_graph, to_save_gdf, to_save_gdf_names)
-        if self.analysis.save_csv:
-            csv_path = _output_path.joinpath(
-                self.analysis.name.replace(" ", "_") + "_destinations.csv"
-            )
-            if "geometry" in destinations.columns:
-                del destinations["geometry"]
-            if not csv_path.parent.exists():
-                csv_path.parent.mkdir(parents=True)
-            destinations.to_csv(csv_path, index=False)
-
-            csv_path = _output_path.joinpath(
-                self.analysis.name.replace(" ", "_") + "_optimal_routes.csv"
-            )
-            if not opt_routes_without_hazard.empty:
-                del opt_routes_without_hazard["geometry"]
-                opt_routes_without_hazard.to_csv(csv_path, index=False)
-            if not opt_routes_with_hazard.empty:
-                del opt_routes_with_hazard["geometry"]
-                opt_routes_with_hazard.to_csv(csv_path, index=False)
+        )
 
         if self.graph_file_hazard.file is not None:
             agg_results.to_excel(
@@ -170,5 +115,4 @@ class MultiLinkOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
                 index=False,
             )
 
-        # TODO: This does not seem correct, why were we returning None?
-        return self.generate_result_wrapper(None)
+        return _analysis_result_wrapper

--- a/ra2ce/analysis/losses/optimal_route_origin_closest_destination.py
+++ b/ra2ce/analysis/losses/optimal_route_origin_closest_destination.py
@@ -8,6 +8,7 @@ from ra2ce.analysis.analysis_config_data.analysis_config_data import (
     AnalysisSectionLosses,
 )
 from ra2ce.analysis.analysis_input_wrapper import AnalysisInputWrapper
+from ra2ce.analysis.analysis_result.analysis_result import AnalysisResult
 from ra2ce.analysis.analysis_result.analysis_result_wrapper import AnalysisResultWrapper
 from ra2ce.analysis.losses.analysis_losses_protocol import AnalysisLossesProtocol
 from ra2ce.analysis.losses.origin_closest_destination import OriginClosestDestination
@@ -44,74 +45,30 @@ class OptimalRouteOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol)
         self.file_id = analysis_input.file_id
         self._analysis_input = analysis_input
 
-    def _save_gdf(self, gdf: GeoDataFrame, save_path: Path):
-        """Takes in a geodataframe object and outputs shapefiles at the paths indicated by edge_shp and node_shp
-
-        Arguments:
-            gdf [geodataframe]: geodataframe object to be converted
-            save_path [str]: output path including extension for edges shapefile
-        Returns:
-            None
-        """
-        # save to shapefile
-        gdf.crs = "epsg:4326"  # TODO: decide if this should be variable with e.g. an output_crs configured
-
-        for col in gdf.columns:
-            if gdf[col].dtype == object and col != gdf.geometry.name:
-                gdf[col] = gdf[col].astype(str)
-
-        if save_path.exists():
-            save_path.unlink()
-        gdf.to_file(save_path, driver="GPKG")
-        logging.info("Results saved to: {}".format(save_path))
-
     def execute(self) -> AnalysisResultWrapper:
-        def _save_gpkg_analysis(
-            base_graph,
-            to_save_gdf: list[GeoDataFrame],
-            to_save_gdf_names: list[str],
-        ):
-            for to_save, save_name in zip(to_save_gdf, to_save_gdf_names):
-                if not to_save.empty:
-                    gpkg_path = _output_path.joinpath(
-                        self.analysis.name.replace(" ", "_") + f"_{save_name}.gpkg"
-                    )
-                    self._save_gdf(to_save, gpkg_path)
-
-            # Save the Graph
-            gpkg_path_nodes = _output_path.joinpath(
-                self.analysis.name.replace(" ", "_") + "_results_nodes.gpkg"
-            )
-            gpkg_path_edges = _output_path.joinpath(
-                self.analysis.name.replace(" ", "_") + "_results_edges.gpkg"
-            )
-            graph_to_gpkg(base_graph, gpkg_path_edges, gpkg_path_nodes)
-
-        _output_path = self.output_path.joinpath(self.analysis.analysis.config_value)
-
         analyzer = OriginClosestDestination(self._analysis_input)
         (
-            base_graph,
+            _,
             opt_routes,
             destinations,
         ) = analyzer.optimal_route_origin_closest_destination()
-        if self.analysis.save_gpkg:
-            # Save the GeoDataFrames
-            to_save_gdf = [destinations, opt_routes]
-            to_save_gdf_names = ["destinations", "optimal_routes"]
-            _save_gpkg_analysis(base_graph, to_save_gdf, to_save_gdf_names)
 
-        if self.analysis.save_csv:
-            csv_path = _output_path.joinpath(
-                self.analysis.name.replace(" ", "_") + "_destinations.csv"
-            )
-            del destinations["geometry"]
-            destinations.to_csv(csv_path, index=False)
-
-            csv_path = _output_path.joinpath(
-                self.analysis.name.replace(" ", "_") + "_optimal_routes.csv"
-            )
-            del opt_routes["geometry"]
-            opt_routes.to_csv(csv_path, index=False)
         # TODO: This does not seem correct, why were we returning None?
-        return self.generate_result_wrapper(None)
+        def get_analysis_result(
+            gdf_result: GeoDataFrame, suffix_name: str
+        ) -> AnalysisResult:
+            _ar = AnalysisResult(
+                analysis_result=gdf_result,
+                analysis_config=self.analysis,
+                output_path=self.output_path,
+            )
+            _ar.analysis_name = self.analysis.name.replace(" ", "_") + suffix_name
+            return _ar
+
+        return AnalysisResultWrapper(
+            results_collection=[
+                # CSV
+                get_analysis_result(destinations, "_destinations"),
+                get_analysis_result(opt_routes, "_optimal_routes"),
+            ]
+        )

--- a/ra2ce/analysis/losses/optimal_route_origin_closest_destination.py
+++ b/ra2ce/analysis/losses/optimal_route_origin_closest_destination.py
@@ -1,4 +1,3 @@
-import logging
 from pathlib import Path
 
 from geopandas import GeoDataFrame
@@ -17,7 +16,6 @@ from ra2ce.network.hazard.hazard_names import HazardNames
 from ra2ce.network.network_config_data.network_config_data import (
     OriginsDestinationsSection,
 )
-from ra2ce.network.networks_utils import graph_to_gpkg
 
 
 class OptimalRouteOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol):
@@ -46,14 +44,6 @@ class OptimalRouteOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol)
         self._analysis_input = analysis_input
 
     def execute(self) -> AnalysisResultWrapper:
-        analyzer = OriginClosestDestination(self._analysis_input)
-        (
-            _,
-            opt_routes,
-            destinations,
-        ) = analyzer.optimal_route_origin_closest_destination()
-
-        # TODO: This does not seem correct, why were we returning None?
         def get_analysis_result(
             gdf_result: GeoDataFrame, suffix_name: str
         ) -> AnalysisResult:
@@ -65,9 +55,18 @@ class OptimalRouteOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol)
             _ar.analysis_name = self.analysis.name.replace(" ", "_") + suffix_name
             return _ar
 
+        analyzer = OriginClosestDestination(self._analysis_input)
+
+        # Get gdfs
+        (
+            base_graph,
+            opt_routes,
+            destinations,
+        ) = analyzer.optimal_route_origin_closest_destination()
+
         return AnalysisResultWrapper(
             results_collection=[
-                # CSV
+                get_analysis_result(base_graph, "_origins"),
                 get_analysis_result(destinations, "_destinations"),
                 get_analysis_result(opt_routes, "_optimal_routes"),
             ]

--- a/ra2ce/analysis/losses/optimal_route_origin_closest_destination.py
+++ b/ra2ce/analysis/losses/optimal_route_origin_closest_destination.py
@@ -44,17 +44,6 @@ class OptimalRouteOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol)
         self._analysis_input = analysis_input
 
     def execute(self) -> AnalysisResultWrapper:
-        def get_analysis_result(
-            gdf_result: GeoDataFrame, suffix_name: str
-        ) -> AnalysisResult:
-            _ar = AnalysisResult(
-                analysis_result=gdf_result,
-                analysis_config=self.analysis,
-                output_path=self.output_path,
-            )
-            _ar.analysis_name = self.analysis.name.replace(" ", "_") + suffix_name
-            return _ar
-
         analyzer = OriginClosestDestination(self._analysis_input)
 
         # Get gdfs
@@ -63,11 +52,11 @@ class OptimalRouteOriginClosestDestination(AnalysisBase, AnalysisLossesProtocol)
             opt_routes,
             destinations,
         ) = analyzer.optimal_route_origin_closest_destination()
-
+        _base_name = self.analysis.name.replace(" ", "_")
         return AnalysisResultWrapper(
             results_collection=[
-                get_analysis_result(base_graph, "_origins"),
-                get_analysis_result(destinations, "_destinations"),
-                get_analysis_result(opt_routes, "_optimal_routes"),
+                self._get_analysis_result(base_graph, _base_name + "_origins"),
+                self._get_analysis_result(destinations, _base_name + "_destinations"),
+                self._get_analysis_result(opt_routes, _base_name + "_optimal_routes"),
             ]
         )

--- a/ra2ce/analysis/losses/optimal_route_origin_closest_destination.py
+++ b/ra2ce/analysis/losses/optimal_route_origin_closest_destination.py
@@ -1,13 +1,10 @@
 from pathlib import Path
 
-from geopandas import GeoDataFrame
-
 from ra2ce.analysis.analysis_base import AnalysisBase
 from ra2ce.analysis.analysis_config_data.analysis_config_data import (
     AnalysisSectionLosses,
 )
 from ra2ce.analysis.analysis_input_wrapper import AnalysisInputWrapper
-from ra2ce.analysis.analysis_result.analysis_result import AnalysisResult
 from ra2ce.analysis.analysis_result.analysis_result_wrapper import AnalysisResultWrapper
 from ra2ce.analysis.losses.analysis_losses_protocol import AnalysisLossesProtocol
 from ra2ce.analysis.losses.origin_closest_destination import OriginClosestDestination

--- a/ra2ce/network/exporters/geodataframe_network_exporter.py
+++ b/ra2ce/network/exporters/geodataframe_network_exporter.py
@@ -29,13 +29,18 @@ from ra2ce.network.exporters.network_exporter_base import NetworkExporterBase
 
 class GeoDataFrameNetworkExporter(NetworkExporterBase):
     def export_to_gpkg(self, output_dir: Path, export_data: gpd.GeoDataFrame) -> None:
-        _output_shp_path = output_dir / (self._basename + ".gpkg")
+        _output_gpkg_path = output_dir.joinpath(self.basename + ".gpkg")
+
+        if _output_gpkg_path.exists():
+            logging.info("Removing previous gpkg file %s.", _output_gpkg_path)
+            _output_gpkg_path.unlink()
+
         export_data.to_file(
-            _output_shp_path, index=False
-        )  # , encoding='utf-8' -Removed the encoding type because this causes some shapefiles not to save.
-        logging.info(f"Saved {_output_shp_path.stem} in {output_dir}.")
+            _output_gpkg_path, index=False, driver="GPKG", encoding="utf-8"
+        )
+        logging.info("Saved %s in %s.", _output_gpkg_path.stem, output_dir)
 
     def export_to_pickle(self, output_dir: Path, export_data: gpd.GeoDataFrame) -> None:
-        self.pickle_path = output_dir / (self._basename + ".feather")
+        self.pickle_path = output_dir.joinpath(self.basename + ".feather")
         export_data.to_feather(self.pickle_path, index=False)
-        logging.info(f"Saved {self.pickle_path.stem} in {output_dir}.")
+        logging.info("Saved %s in %s.", self.pickle_path.stem, output_dir)

--- a/ra2ce/network/exporters/multi_graph_network_exporter.py
+++ b/ra2ce/network/exporters/multi_graph_network_exporter.py
@@ -45,18 +45,11 @@ class MultiGraphNetworkExporter(NetworkExporterBase):
 
         # Export through the single gdf exporter
         _gdf_exporter = GeoDataFrameNetworkExporter(basename=self.basename)
-        _gdf_exporter.basename = self.basename + "_edges.gpkg"
+        _gdf_exporter.basename = self.basename + "_edge"
         _gdf_exporter.export_to_gpkg(output_dir, _edges_graph)
 
-        _gdf_exporter.basename = self.basename + "_nodes.gpkg"
+        _gdf_exporter.basename = self.basename + "_nodes"
         _gdf_exporter.export_to_gpkg(output_dir, _nodes_graph)
-
-        logging.info(
-            "Saved %s and %s in %s.",
-            self.basename + "_edges.gpkg",
-            self.basename + "_nodes.gpkg",
-            output_dir,
-        )
 
     def export_to_pickle(self, output_dir: Path, export_data: MULTIGRAPH_TYPE) -> None:
         self.pickle_path = output_dir.joinpath(self.basename + ".p")

--- a/ra2ce/network/exporters/multi_graph_network_exporter.py
+++ b/ra2ce/network/exporters/multi_graph_network_exporter.py
@@ -46,10 +46,10 @@ class MultiGraphNetworkExporter(NetworkExporterBase):
         # Export through the single gdf exporter
         _gdf_exporter = GeoDataFrameNetworkExporter(basename=self.basename)
         _gdf_exporter.basename = self.basename + "_edges.gpkg"
-        _gdf_exporter.export(output_dir, _edges_graph)
+        _gdf_exporter.export_to_gpkg(output_dir, _edges_graph)
 
         _gdf_exporter.basename = self.basename + "_nodes.gpkg"
-        _gdf_exporter.export(output_dir, _nodes_graph)
+        _gdf_exporter.export_to_gpkg(output_dir, _nodes_graph)
 
         logging.info(
             "Saved %s and %s in %s.",

--- a/ra2ce/network/exporters/multi_graph_network_exporter.py
+++ b/ra2ce/network/exporters/multi_graph_network_exporter.py
@@ -45,7 +45,7 @@ class MultiGraphNetworkExporter(NetworkExporterBase):
 
         # Export through the single gdf exporter
         _gdf_exporter = GeoDataFrameNetworkExporter(basename=self.basename)
-        _gdf_exporter.basename = self.basename + "_edge"
+        _gdf_exporter.basename = self.basename + "_edges"
         _gdf_exporter.export_to_gpkg(output_dir, _edges_graph)
 
         _gdf_exporter.basename = self.basename + "_nodes"

--- a/ra2ce/network/exporters/multi_graph_network_exporter.py
+++ b/ra2ce/network/exporters/multi_graph_network_exporter.py
@@ -24,11 +24,14 @@ import pickle
 from pathlib import Path
 from typing import Optional
 
+from ra2ce.network.exporters.geodataframe_network_exporter import (
+    GeoDataFrameNetworkExporter,
+)
 from ra2ce.network.exporters.network_exporter_base import (
     MULTIGRAPH_TYPE,
     NetworkExporterBase,
 )
-from ra2ce.network.networks_utils import graph_to_gpkg
+from ra2ce.network.networks_utils import get_nodes_and_edges_from_origin_graph
 
 
 class MultiGraphNetworkExporter(NetworkExporterBase):
@@ -38,20 +41,27 @@ class MultiGraphNetworkExporter(NetworkExporterBase):
         if not output_dir.is_dir():
             output_dir.mkdir(parents=True)
 
-        # TODO: This method should be a writer itself.
-        graph_to_gpkg(
-            export_data,
-            output_dir / (self._basename + "_edges.gpkg"),
-            output_dir / (self._basename + "_nodes.gpkg"),
-        )
+        _nodes_graph, _edges_graph = get_nodes_and_edges_from_origin_graph(export_data)
+
+        # Export through the single gdf exporter
+        _gdf_exporter = GeoDataFrameNetworkExporter(basename=self.basename)
+        _gdf_exporter.basename = self.basename + "_edges.gpkg"
+        _gdf_exporter.export(output_dir, _edges_graph)
+
+        _gdf_exporter.basename = self.basename + "_nodes.gpkg"
+        _gdf_exporter.export(output_dir, _nodes_graph)
+
         logging.info(
-            f"Saved {self._basename + '_edges.gpkg'} and {self._basename + '_nodes.gpkg'} in {output_dir}."
+            "Saved %s and %s in %s.",
+            self.basename + "_edges.gpkg",
+            self.basename + "_nodes.gpkg",
+            output_dir,
         )
 
     def export_to_pickle(self, output_dir: Path, export_data: MULTIGRAPH_TYPE) -> None:
-        self.pickle_path = output_dir / (self._basename + ".p")
+        self.pickle_path = output_dir.joinpath(self.basename + ".p")
         with open(self.pickle_path, "wb") as f:
             pickle.dump(export_data, f, protocol=4)
         logging.info(
-            f"Saved {self.pickle_path.stem} in {self.pickle_path.resolve().parent}."
+            "Saved %s in %s.", self.pickle_path.stem, self.pickle_path.resolve().parent
         )

--- a/ra2ce/network/exporters/network_exporter_base.py
+++ b/ra2ce/network/exporters/network_exporter_base.py
@@ -20,6 +20,7 @@
 """
 
 
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import geopandas as gpd
@@ -31,15 +32,11 @@ MULTIGRAPH_TYPE = nx.MultiGraph | nx.MultiDiGraph
 NETWORK_TYPE = gpd.GeoDataFrame | MULTIGRAPH_TYPE
 
 
+@dataclass(kw_only=True)
 class NetworkExporterBase(Ra2ceExporterProtocol):
-    _basename: str
-    _export_types: list[str] = ["pickle"]
-    pickle_path: Path
-
-    def __init__(self, basename: str, export_types: list[str]) -> None:
-        self._basename = basename
-        self._export_types = export_types
-        self.pickle_path = None
+    basename: str
+    export_types: list[str] = field(default_factory=["pickle"])
+    pickle_path: Path = None
 
     def export_to_gpkg(self, output_dir: Path, export_data: NETWORK_TYPE) -> None:
         """
@@ -70,8 +67,8 @@ class NetworkExporterBase(Ra2ceExporterProtocol):
             export_path (Path): Path to the output directory where to export the data.
             export_data (NETWORK_TYPE): Data that needs to be exported.
         """
-        if "pickle" in self._export_types:
+        if "pickle" in self.export_types:
             self.export_to_pickle(export_path, export_data)
 
-        if "gpkg" in self._export_types:
+        if "gpkg" in self.export_types:
             self.export_to_gpkg(export_path, export_data)

--- a/ra2ce/network/exporters/network_exporter_base.py
+++ b/ra2ce/network/exporters/network_exporter_base.py
@@ -35,7 +35,7 @@ NETWORK_TYPE = gpd.GeoDataFrame | MULTIGRAPH_TYPE
 @dataclass(kw_only=True)
 class NetworkExporterBase(Ra2ceExporterProtocol):
     basename: str
-    export_types: list[str] = field(default_factory=["pickle"])
+    export_types: list[str] = field(default_factory=lambda: ["pickle"])
     pickle_path: Path = None
 
     def export_to_gpkg(self, output_dir: Path, export_data: NETWORK_TYPE) -> None:

--- a/ra2ce/network/exporters/network_exporter_factory.py
+++ b/ra2ce/network/exporters/network_exporter_factory.py
@@ -47,7 +47,7 @@ class NetworkExporterFactory:
         export_types: list[str],
     ) -> None:
         _exporter_type = self.get_exporter_type(network)
-        self._exporter = _exporter_type(basename, export_types)
+        self._exporter = _exporter_type(basename=basename, export_types=export_types)
         self._exporter.export(output_dir, network)
 
     def get_pickle_path(self) -> Path:

--- a/ra2ce/network/networks_utils.py
+++ b/ra2ce/network/networks_utils.py
@@ -1182,34 +1182,6 @@ def get_nodes_and_edges_from_origin_graph(
     return _nodes, _edges
 
 
-@DeprecationWarning
-def graph_to_gpkg(origin_graph: nx.Graph, edge_gpkg: str, node_gpkg: str) -> None:
-    """
-    Arguments:
-        origin_graph [nx.Graph]: networkx graph object to be converted
-        edge_gpkg [str]: output path including extension for edges geopackage
-        node_gpkg [str]: output path including extension for nodes geopackage
-
-    Returns:
-        None
-    """
-    _nodes_graph, _edges_graph = get_nodes_and_edges_from_origin_graph(origin_graph)
-
-    logging.info("Saving nodes as shapefile: %s", node_gpkg)
-    logging.info("Saving edges as shapefile: %s", edge_gpkg)
-
-    # The encoding utf-8 might result in an empty shapefile if the wrong encoding is used.
-    for entity in [_nodes_graph, _edges_graph]:
-        if "osmid" in entity:
-            # Otherwise it gives this error: cannot insert osmid, already exist
-            entity["osmid_original"] = entity.pop("osmid")
-    for _path in [node_gpkg, edge_gpkg]:
-        if _path.exists():
-            _path.unlink()
-    _nodes_graph.to_file(node_gpkg, driver="GPKG", encoding="utf-8")
-    _edges_graph.to_file(edge_gpkg, driver="GPKG", encoding="utf-8")
-
-
 @staticmethod
 def get_normalized_geojson_polygon(geojson_path: Path) -> BaseGeometry:
     """

--- a/ra2ce/network/networks_utils.py
+++ b/ra2ce/network/networks_utils.py
@@ -1157,7 +1157,8 @@ def get_nodes_and_edges_from_origin_graph(
             resulting tuple of formatted `gpd.GeoDataFrame` for nodes and edges.
     """
     # now only multidigraphs and graphs are used
-    if isinstance(origin_graph, nx.Graph):
+    if type(origin_graph) == nx.Graph:
+        # isinstance / issubclass will not work as nx.MultiGraph would return True
         origin_graph = nx.MultiGraph(origin_graph)
 
     # The nodes should have a geometry attribute (perhaps on top of the x and y attributes)

--- a/ra2ce/network/networks_utils.py
+++ b/ra2ce/network/networks_utils.py
@@ -1182,11 +1182,9 @@ def get_nodes_and_edges_from_origin_graph(
     return _nodes, _edges
 
 
+@DeprecationWarning
 def graph_to_gpkg(origin_graph: nx.Graph, edge_gpkg: str, node_gpkg: str) -> None:
     """
-    [DEPRECATED] Please  use instead `AnalysisResultWrapperExporter`.
-    Takes in a networkx graph object and outputs shapefiles at the paths indicated by edge_gpkg and node_gpkg
-
     Arguments:
         origin_graph [nx.Graph]: networkx graph object to be converted
         edge_gpkg [str]: output path including extension for edges geopackage
@@ -1197,8 +1195,8 @@ def graph_to_gpkg(origin_graph: nx.Graph, edge_gpkg: str, node_gpkg: str) -> Non
     """
     _nodes_graph, _edges_graph = get_nodes_and_edges_from_origin_graph(origin_graph)
 
-    logging.info("Saving nodes as shapefile: %s".format(node_gpkg))
-    logging.info("Saving edges as shapefile: %s".format(edge_gpkg))
+    logging.info("Saving nodes as shapefile: %s", node_gpkg)
+    logging.info("Saving edges as shapefile: %s", edge_gpkg)
 
     # The encoding utf-8 might result in an empty shapefile if the wrong encoding is used.
     for entity in [_nodes_graph, _edges_graph]:

--- a/tests/network/exporters/test_geodataframe_network_exporter.py
+++ b/tests/network/exporters/test_geodataframe_network_exporter.py
@@ -1,4 +1,5 @@
 import shutil
+from pathlib import Path
 
 import pytest
 from geopandas import GeoDataFrame
@@ -7,25 +8,28 @@ from ra2ce.network.exporters.geodataframe_network_exporter import (
     GeoDataFrameNetworkExporter,
 )
 from ra2ce.network.exporters.network_exporter_base import NetworkExporterBase
-from tests import test_results
 
 
 class TestGeodataframeNetworkExporter:
     def test_initialize(self):
         _basename = "dummy_test"
-        _exporter = GeoDataFrameNetworkExporter(_basename, ["pickle", "gpkg"])
+        _exporter = GeoDataFrameNetworkExporter(
+            basename=_basename, export_types=["pickle", "gpkg"]
+        )
         assert isinstance(_exporter, GeoDataFrameNetworkExporter)
         assert isinstance(_exporter, NetworkExporterBase)
 
     @pytest.mark.skip(reason="TODO: Needs to define GeoDataFrame dummydata.")
-    def test_export_to_gpkg(self, request: pytest.FixtureRequest):
+    def test_export_to_gpkg(self, test_result_param_case: Path):
         # 1. Define test data.
-        _output_dir = test_results / request.node.name
+        _output_dir = test_result_param_case
         if _output_dir.is_dir():
             shutil.rmtree(_output_dir)
 
         _basename = "dummy_test"
-        _exporter = GeoDataFrameNetworkExporter(_basename, ["pickle", "gpkg"])
+        _exporter = GeoDataFrameNetworkExporter(
+            basename=_basename, export_types=["pickle", "gpkg"]
+        )
 
         _export_data = GeoDataFrame()
 
@@ -37,14 +41,16 @@ class TestGeodataframeNetworkExporter:
         assert (_output_dir / (_basename + ".gpkg")).is_file()
 
     @pytest.mark.skip(reason="TODO: Needs to define GeoDataFrame dummydata.")
-    def test_export_to_pickle(self, request: pytest.FixtureRequest):
+    def test_export_to_pickle(self, test_result_param_case: Path):
         # 1. Define test data.
-        _output_dir = test_results / request.node.name
+        _output_dir = test_result_param_case
         if _output_dir.is_dir():
             shutil.rmtree(_output_dir)
 
         _basename = "dummy_test"
-        _exporter = GeoDataFrameNetworkExporter(_basename, ["pickle", "gpkg"])
+        _exporter = GeoDataFrameNetworkExporter(
+            basename=_basename, export_types=["pickle", "gpkg"]
+        )
 
         _export_data = GeoDataFrame()
 

--- a/tests/network/exporters/test_multi_graph_network_exporter.py
+++ b/tests/network/exporters/test_multi_graph_network_exporter.py
@@ -12,7 +12,9 @@ from tests import test_results
 
 class TestMultigraphNetworkExporter:
     def test_initialize(self):
-        _exporter = MultiGraphNetworkExporter("_basename", ["pickle", "gpkg"])
+        _exporter = MultiGraphNetworkExporter(
+            basename="_basename", export_types=["pickle", "gpkg"]
+        )
         assert isinstance(_exporter, MultiGraphNetworkExporter)
         assert isinstance(_exporter, NetworkExporterBase)
         assert isinstance(_exporter, Ra2ceExporterProtocol)
@@ -23,7 +25,9 @@ class TestMultigraphNetworkExporter:
         """
         # 1. Define test data.
         _basename = "dummy_test"
-        _exporter = MultiGraphNetworkExporter(_basename, ["pickle", "gpkg"])
+        _exporter = MultiGraphNetworkExporter(
+            basename=_basename, export_types=["pickle", "gpkg"]
+        )
         _test_dir = test_results / request.node.name
         if _test_dir.is_dir():
             shutil.rmtree(_test_dir)
@@ -42,7 +46,9 @@ class TestMultigraphNetworkExporter:
     def test_export_to_pickle(self, request: pytest.FixtureRequest):
         # 1. Define test data.
         _basename = "dummy_test"
-        _exporter = MultiGraphNetworkExporter(_basename, ["pickle", "gpkg"])
+        _exporter = MultiGraphNetworkExporter(
+            basename=_basename, export_types=["pickle", "gpkg"]
+        )
         _test_dir = test_results / request.node.name
         if _test_dir.is_dir():
             shutil.rmtree(_test_dir)

--- a/tests/network/exporters/test_network_exporter_base.py
+++ b/tests/network/exporters/test_network_exporter_base.py
@@ -7,7 +7,7 @@ from tests import test_results
 
 class TestNetworkExporterBase:
     def test_initialize(self):
-        _exporter_base = NetworkExporterBase("a_name", [])
+        _exporter_base = NetworkExporterBase(basename="a_name", export_types=[])
         assert isinstance(_exporter_base, NetworkExporterBase)
         assert isinstance(_exporter_base, Ra2ceExporterProtocol)
         assert _exporter_base.export_types == []
@@ -18,7 +18,9 @@ class TestNetworkExporterBase:
         _output_dir = test_results / request.node.name
 
         # 2. Run test.
-        _exporter_base = NetworkExporterBase("a_name", [export_type])
+        _exporter_base = NetworkExporterBase(
+            basename="a_name", export_types=[export_type]
+        )
         _result = _exporter_base.export(_output_dir, None)
 
         # 3. Verify expectations.

--- a/tests/network/exporters/test_network_exporter_base.py
+++ b/tests/network/exporters/test_network_exporter_base.py
@@ -10,7 +10,7 @@ class TestNetworkExporterBase:
         _exporter_base = NetworkExporterBase("a_name", [])
         assert isinstance(_exporter_base, NetworkExporterBase)
         assert isinstance(_exporter_base, Ra2ceExporterProtocol)
-        assert _exporter_base._export_types == []
+        assert _exporter_base.export_types == []
 
     @pytest.mark.parametrize("export_type", [("pickle"), ("gpkg")])
     def test_export_data(self, export_type: str, request: pytest.FixtureRequest):

--- a/tests/network/test_networks.py
+++ b/tests/network/test_networks.py
@@ -105,7 +105,7 @@ class TestNetworks:
 
         # 3. Then verify expectations.
         def validate_file(filename: str):
-            _graph_file = _output_graph_dir / filename
+            _graph_file = _output_graph_dir.joinpath(filename)
             return _graph_file.is_file() and _graph_file.exists()
 
         assert isinstance(_network_controller, GraphFilesCollection)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -228,18 +228,19 @@ class TestMainCli:
             return filepath.exists() and filepath.is_file()
 
         # Graph files
-        assert all(_verify_file(_graph_dir / _f) for _f in expected_graph_files)
+        assert all(_verify_file(_graph_dir.joinpath(_f)) for _f in expected_graph_files)
 
         # Analysis files
-        assert all(
-            list(
-                chain(
-                    *(
-                        list(
-                            map(lambda x: _verify_file(_analysis_dir.joinpath(k, x)), v)
-                        )
-                        for k, v in expected_analysis_files.items()
-                    )
+        _not_generated_files = []
+        for _subdir_name, _subdir_files in expected_analysis_files.items():
+            _not_generated_files.extend(
+                filter(
+                    lambda x: not _verify_file(_analysis_dir.joinpath(_subdir_name, x)),
+                    _subdir_files,
                 )
             )
-        )
+        _err_mssg = ", ".join(_not_generated_files)
+        if any(_not_generated_files):
+            pytest.fail(
+                "The following expected files were not generated: {}".format(_err_mssg)
+            )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -235,7 +235,9 @@ class TestMainCli:
             list(
                 chain(
                     *(
-                        list(map(lambda x: _verify_file(_analysis_dir / k / x), v))
+                        list(
+                            map(lambda x: _verify_file(_analysis_dir.joinpath(k, x)), v)
+                        )
                         for k, v in expected_analysis_files.items()
                     )
                 )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -241,6 +241,4 @@ class TestMainCli:
             )
         _err_mssg = ", ".join(_not_generated_files)
         if any(_not_generated_files):
-            pytest.fail(
-                "The following expected files were not generated: {}".format(_err_mssg)
-            )
+            pytest.fail(f"The following expected files were not generated: {_err_mssg}")


### PR DESCRIPTION
## Issue addressed
Solves #632 

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [x] I HAVE discussed my solution with (other) members of the RA2CE team.

## What has been done?
- Removed export logic from `MultiLinkOriginClosestDestination` and `OptimalRouteOriginClosestDestination`.
- Results from `multi_link_origin_closest_destination` are now mapped into an `AnalysisResult`, as part of the returning `AnalysisResultWrapper.results_collection`.
- Results from `optimal_route_origin_closest_destination` are now mapped into an `AnalysisResult`, as part of the returning `AnalysisResultWrapper.results_collection`.
- Extended `AnalysisBase` to reduce code duplication.
- Small refactor to `network_utils` so we can retrieve the transformed `GeoDataFrame` directly using `get_nodes_and_edges_from_origin_graph` instead of doing a direct export.
- Refactored `NetworkExporterBase` and its concrete classes to avoid calling / using the "export" in `network_utils.py`
- Removed `graph_to_gpkg` as it is no longer needed.

### Checklist
- [x] Code is formatted using our custom `black` and `isort` definitions.
- [x] Tests are either added or updated.
- [x] Branch is up to date with `master`.
- [ ] Updated documentation if needed.

## Additional Notes (optional)
This PR mostly aims to reduce export during "analysis" time, delegating all the exports (to `.csv` and `.gpkg` after the analysis is run.
