### PR TITLE
fix: Corrected primary and diversion file property types to `Path`

### DIFF
--- a/examples/example_adaptation.ipynb
+++ b/examples/example_adaptation.ipynb
@@ -91,7 +91,7 @@
     "\n",
     "_network_section = NetworkSection(\n",
     "    source= SourceEnum.SHAPEFILE,       \n",
-    "    primary_file = [network_path.joinpath(\"network.shp\")], \n",
+    "    primary_file = network_path.joinpath(\"network.shp\"), \n",
     "    file_id = \"ID\",\n",
     "    link_type_column=\"highway\",\n",
     "    save_gpkg=True,\n",

--- a/examples/example_multi_link_losses_estimated_annual_losses.ipynb
+++ b/examples/example_multi_link_losses_estimated_annual_losses.ipynb
@@ -308,7 +308,7 @@
     "network_section = NetworkSection(\n",
     "    directed=False,                     #Used together with OSM download - False if you want to have an undirected graph and True if you want to have a directed graph.\n",
     "    source= SourceEnum.SHAPEFILE,       #Used to specify the shapefile name of the (road) network to do the analysis with, when creating a network from a shapefile. *only this is supported\n",
-    "    primary_file = [root_dir/\"static\"/\"network\"/\"network.shp\"], #soecify in the RA2CE folder setup where the network is locates\n",
+    "    primary_file = root_dir/\"static\"/\"network\"/\"network.shp\", #soecify in the RA2CE folder setup where the network is locates\n",
     "    diversion_file= None,\n",
     "    file_id = \"ID\", #should be the same as the traffic intensity file link id column name\n",
     "    link_type_column='highway',\n",

--- a/examples/example_single_link_losses_estimated_annual_losses.ipynb
+++ b/examples/example_single_link_losses_estimated_annual_losses.ipynb
@@ -297,7 +297,7 @@
     "network_section = NetworkSection(\n",
     "    directed=False,                     #Used together with OSM download - False if you want to have an undirected graph and True if you want to have a directed graph. \n",
     "    source= SourceEnum.SHAPEFILE,       #Used to specify the shapefile name of the (road) network to do the analysis with, when creating a network from a shapefile.*only this is supported\n",
-    "    primary_file = [root_dir/\"static\"/\"network\"/\"network.shp\"], #soecify in the RA2CE folder setup where the network is locates\n",
+    "    primary_file = root_dir/\"static\"/\"network\"/\"network.shp\", #soecify in the RA2CE folder setup where the network is locates\n",
     "    diversion_file= None,\n",
     "    file_id = \"ID\", #should be the same as the traffic intensity file link id column name\n",
     "    link_type_column='highway',\n",

--- a/examples/tech_meetings/20241213_run_damages_losses_without_files.ipynb
+++ b/examples/tech_meetings/20241213_run_damages_losses_without_files.ipynb
@@ -79,7 +79,7 @@
    "source": [
     "_network_section = NetworkSection(\n",
     "    source= SourceEnum.SHAPEFILE,       \n",
-    "    primary_file = [network_path.joinpath(\"network.shp\")], \n",
+    "    primary_file = network_path.joinpath(\"network.shp\"), \n",
     "    file_id = \"ID\",\n",
     "    link_type_column=\"highway\",\n",
     "    save_gpkg=True\n",

--- a/ra2ce/network/network_config_data/network_config_data.py
+++ b/ra2ce/network/network_config_data/network_config_data.py
@@ -43,8 +43,8 @@ class ProjectSection:
 class NetworkSection:
     directed: bool = False
     source: SourceEnum = field(default_factory=lambda: SourceEnum.INVALID)
-    primary_file: list[Path] = field(default_factory=list)
-    diversion_file: list[Path] = field(default_factory=list)
+    primary_file: Optional[Path] = None
+    diversion_file: Optional[Path] = None
     file_id: str = ""
     link_type_column: str = "highway"
     polygon: Optional[Path] = None

--- a/ra2ce/network/network_config_data/network_config_data_reader.py
+++ b/ra2ce/network/network_config_data/network_config_data_reader.py
@@ -93,12 +93,8 @@ class NetworkConfigDataReader(ConfigDataReaderProtocol):
                 config_data.network.polygon
             )
 
-        config_data.network.primary_file = _correct_list(
-            _network_directory, config_data.network.primary_file
-        )
-        config_data.network.diversion_file = _correct_list(
-            _network_directory, config_data.network.diversion_file
-        )
+        config_data.network.primary_file = _network_directory.joinpath(config_data.network.primary_file)
+        config_data.network.diversion_file = _network_directory.joinpath(config_data.network.diversion_file)
 
         # Relative to hazard directory.
         _hazard_directory = config_data.static_path.joinpath("hazard")
@@ -147,12 +143,8 @@ class NetworkConfigDataReader(ConfigDataReaderProtocol):
         _network_section.source = SourceEnum.get_enum(
             self._parser.get(_section, "source", fallback=None)
         )
-        _network_section.primary_file = self._get_path_list(
-            _section, "primary_file", _network_section.primary_file
-        )
-        _network_section.diversion_file = self._get_path_list(
-            _section, "diversion_file", _network_section.diversion_file
-        )
+        _network_section.primary_file = self._get_str_as_path( _network_section.primary_file)
+        _network_section.diversion_file = self._get_str_as_path(_network_section.diversion_file)
         _network_section.directed = self._parser.getboolean(
             _section, "directed", fallback=_network_section.directed
         )

--- a/ra2ce/network/network_config_data/network_config_data_reader.py
+++ b/ra2ce/network/network_config_data/network_config_data_reader.py
@@ -93,8 +93,10 @@ class NetworkConfigDataReader(ConfigDataReaderProtocol):
                 config_data.network.polygon
             )
 
-        config_data.network.primary_file = _network_directory.joinpath(config_data.network.primary_file)
-        config_data.network.diversion_file = _network_directory.joinpath(config_data.network.diversion_file)
+        if _select_to_correct(config_data.network.primary_file):
+            config_data.network.primary_file = _network_directory.joinpath(config_data.network.primary_file)
+        if _select_to_correct(config_data.network.diversion_file):
+            config_data.network.diversion_file = _network_directory.joinpath(config_data.network.diversion_file)
 
         # Relative to hazard directory.
         _hazard_directory = config_data.static_path.joinpath("hazard")

--- a/ra2ce/network/network_wrappers/shp_network_wrapper.py
+++ b/ra2ce/network/network_wrappers/shp_network_wrapper.py
@@ -47,8 +47,8 @@ class ShpNetworkWrapper(NetworkWrapperProtocol):
         self.crs = config_data.crs
 
         # Network options
-        self.primary_files = _network_options.primary_file
-        self.diversion_files = _network_options.diversion_file
+        self.primary_file = _network_options.primary_file
+        self.diversion_file = _network_options.diversion_file
         self.directed = _network_options.directed
         self.file_id = _network_options.file_id
 
@@ -68,17 +68,14 @@ class ShpNetworkWrapper(NetworkWrapperProtocol):
             lines (list of shapely LineStrings): full list of linestrings
             properties (pandas dataframe): attributes of shapefile(s), in order of the linestrings in lines
         """
-        # concatenate all shapefile into one geodataframe and set analysis to 1 or 0 for diversions
-        lines = [gpd.read_file(shp, engine="pyogrio") for shp in self.primary_files]
+        # Generate geodataframe from analysis and set analysis to 1 or 0 for diversions
+        lines = gpd.read_file(self.primary_file, engine="pyogrio")
 
-        if any(self.diversion_files):
-            lines.extend(
-                [
-                    nut.check_crs_gdf(gpd.read_file(shp, engine="pyogrio"), self.crs)
-                    for shp in self.diversion_files
-                ]
-            )
-        lines = pd.concat(lines)
+        if self.diversion_file:
+            lines = pd.concat([
+                lines, 
+                nut.check_crs_gdf(gpd.read_file(self.diversion_file, engine="pyogrio"), self.crs)
+                ])
 
         lines.crs = self.crs
 

--- a/ra2ce/network/network_wrappers/vector_network_wrapper.py
+++ b/ra2ce/network/network_wrappers/vector_network_wrapper.py
@@ -59,7 +59,7 @@ class VectorNetworkWrapper(NetworkWrapperProtocol):
         self.crs = config_data.crs
 
         # Network options
-        self.primary_files = config_data.network.primary_file
+        self.primary_file = config_data.network.primary_file
         self.directed = config_data.network.directed
 
         # Origins Destinations
@@ -159,7 +159,7 @@ class VectorNetworkWrapper(NetworkWrapperProtocol):
         return graph_simple, edges_complex
 
     def _read_vector_to_project_region_and_crs(self) -> gpd.GeoDataFrame:
-        gdf = self._read_files(self.primary_files)
+        gdf = self._read_file(self.primary_file)
         if gdf is None:
             logging.info("no file is read.")
             return None
@@ -175,7 +175,7 @@ class VectorNetworkWrapper(NetworkWrapperProtocol):
 
         # clip for region
         if self.region_path:
-            _region_gpd = self._read_files([self.region_path])
+            _region_gpd = self._read_file(self.region_path)
             gdf = gpd.overlay(gdf, _region_gpd, how="intersection", keep_geom_type=True)
             logging.info("clip vector file to project region")
 
@@ -186,24 +186,18 @@ class VectorNetworkWrapper(NetworkWrapperProtocol):
 
         return gdf
 
-    def _read_files(self, file_list: list[Path]) -> gpd.GeoDataFrame:
-        """Reads a list of files into a GeoDataFrame.
+    def _read_file(self, file_path: Path) -> gpd.GeoDataFrame:
+        """Reads a file into a GeoDataFrame.
 
         Args:
-            file_list (list[Path]): List of file paths.
+            file_path (Path): Path to the geodataframe file.
 
         Returns:
             gpd.GeoDataFrame: GeoDataFrame representing the data.
         """
         # read file
-        gdf = gpd.GeoDataFrame(
-            pd.concat([gpd.read_file(_fl, engine="pyogrio") for _fl in file_list])
-        )
-        logging.info(
-            "Read files {} into a 'GeoDataFrame'.".format(
-                ", ".join(map(str, file_list))
-            )
-        )
+        gdf = gpd.read_file(file_path, engine="pyogrio")
+        logging.info("Read file {} into a 'GeoDataFrame'.".format(file_path))
         return gdf
 
     @staticmethod

--- a/tests/network/network_wrappers/test_vector_network_wrapper.py
+++ b/tests/network/network_wrappers/test_vector_network_wrapper.py
@@ -59,7 +59,7 @@ class TestVectorNetworkWrapper:
         # 3. Verify expectations.
         assert isinstance(_wrapper, VectorNetworkWrapper)
         assert isinstance(_wrapper, NetworkWrapperProtocol)
-        assert _wrapper.primary_files == _config_data.network.primary_file
+        assert _wrapper.primary_file == _config_data.network.primary_file
         assert _wrapper.region_path == _config_data.origins_destinations.region
         assert _wrapper.crs.to_epsg() == 4326
 

--- a/tests/network/network_wrappers/test_vector_network_wrapper.py
+++ b/tests/network/network_wrappers/test_vector_network_wrapper.py
@@ -49,7 +49,7 @@ class TestVectorNetworkWrapper:
             root_path=Path("dummy_path"),
             static_path=Path("dummy_path"),
         )
-        _config_data.network.primary_file = [Path("dummy_primary")]
+        _config_data.network.primary_file = Path("dummy_primary")
         _config_data.network.directed = False
         _config_data.origins_destinations.region = Path("dummy_region")
 
@@ -67,9 +67,7 @@ class TestVectorNetworkWrapper:
     def _valid_wrapper(self, request: pytest.FixtureRequest) -> VectorNetworkWrapper:
         _network_dir = _test_dir.joinpath("static", "network")
         _config_data = NetworkConfigData()
-        _config_data.network.primary_file = [
-            _network_dir.joinpath("_test_lines.geojson")
-        ]
+        _config_data.network.primary_file = _network_dir.joinpath("_test_lines.geojson")
         _config_data.network.directed = False
         _config_data.origins_destinations.region = None
         _config_data.crs = CRS.from_user_input(4326)


### PR DESCRIPTION
## Issue addressed
Solves #700

## Code of conduct
- [x] I HAVE NOT added sensitive or compromised (test) data to the repository.
- [x] I HAVE NOT added vulnerabilities to the repository.
- [x] I HAVE discussed my solution with (other) members of the RA2CE team.

## What has been done?
- `primary_file` and `diversion_file` are now of type `Path` instead of `list[Path]` as we were never using the later type form.
- Updated parser.
- Adapted `shp_network_wrapper` and `vector_network_wrapper` as they were also expecting a list rather than a single `Path`.
- Updated tests and examples.

### Checklist
- [ ] Code is formatted using our custom `black` and `isort` definitions.
- [x] Tests are either added or updated.
- [x] Branch is up to date with `master`.
- [ ] Updated documentation if needed.

## Additional Notes (optional)
- During realization of this issue I came across that `diversion_file` is also not being used as a collection of items, in fact at the `.ini` files we can see both of them referred in 'singular'. Therefore we can conclude that they are only expecting one single file.
